### PR TITLE
Low-priority cleanup batch: #25, #26, #28

### DIFF
--- a/src/components/analytics/AnalyticsAtAGlanceSection.tsx
+++ b/src/components/analytics/AnalyticsAtAGlanceSection.tsx
@@ -37,14 +37,6 @@ import { syncStore } from '@/stores/syncStore'
 
 const WEEK_SHORT = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun']
 
-function emptyYearPoints(monthCount: number): YearMonthPoint[] {
-  return Array.from({ length: monthCount }, (_, i) => ({
-    month: i + 1,
-    moneyIn: 0,
-    moneyOut: 0,
-  }))
-}
-
 function yearMetricValue(p: YearMonthPoint, m: MonthMetric): number {
   if (m === 'spending') return p.moneyOut
   if (m === 'income') return p.moneyIn
@@ -509,16 +501,8 @@ export function AnalyticsAtAGlanceSection() {
               </div>
 
               <YearMonthlyLineChart
-                pointsCurrent={
-                  pointsCurrent.length === 12
-                    ? pointsCurrent
-                    : emptyYearPoints(12)
-                }
-                pointsPrevious={
-                  pointsPrevious.length === 12
-                    ? pointsPrevious
-                    : emptyYearPoints(12)
-                }
+                pointsCurrent={pointsCurrent}
+                pointsPrevious={pointsPrevious}
                 currentThroughMonth={yearCurrentThroughMonth}
                 metric={metric}
                 showCurrentYear={showCurrentYear}

--- a/src/components/atAGlance/ComparisonNarratives.tsx
+++ b/src/components/atAGlance/ComparisonNarratives.tsx
@@ -14,26 +14,10 @@ const NARRATIVE_COLORS: Record<NarrativeInsight['type'], string> = {
 
 export function ComparisonNarratives({
   narratives,
-  priorLabel,
 }: {
   narratives: NarrativeInsight[]
-  priorLabel?: string
 }) {
-  if (narratives.length === 0) {
-    if (!priorLabel) return null
-    return (
-      <div className="mt-3 pt-2 border-top">
-        <div className="d-flex align-items-start gap-1 mb-1">
-          <i
-            className="mdi mdi-check-circle-outline text-success"
-            aria-hidden
-            style={{ fontSize: '0.95rem', marginTop: 1 }}
-          />
-          <span className="small">On track with {priorLabel}</span>
-        </div>
-      </div>
-    )
-  }
+  if (narratives.length === 0) return null
   return (
     <div className="mt-3 pt-2 border-top">
       {narratives.map((n, i) => (

--- a/src/db/schema.migration.test.ts
+++ b/src/db/schema.migration.test.ts
@@ -159,7 +159,7 @@ describe('v36 migration: bank-statement-import removal', () => {
       `SELECT value FROM app_settings WHERE key = 'schema_version'`
     )
     expect(versionRow[0].values[0][0]).toBe(String(SCHEMA_VERSION))
-    expect(SCHEMA_VERSION).toBe(40)
+    expect(SCHEMA_VERSION).toBe(41)
 
     // The credit-card-import account is gone.
     const ccAccount = db.exec(`SELECT * FROM accounts WHERE id = 'cc-visa'`)
@@ -659,6 +659,69 @@ describe('v40 migration: tracker config-history', () => {
       db.exec(`SELECT COUNT(*) FROM tracker_config_history`)[0].values[0][0]
     )
     expect(countAfterSecond).toBe(countAfterFirst)
+    db.close()
+  })
+})
+
+/**
+ * Minimal v40-shaped fixture for the v41 migration, which drops the dead
+ * `transaction_user_data.is_income` column (#26 — no "mark as income" UI ever
+ * read or wrote it). Carries the soon-to-be-dropped column and one populated row.
+ */
+function buildLegacyV40Database(): Database {
+  const db = new SQL.Database()
+  db.run(
+    `CREATE TABLE app_settings (key TEXT PRIMARY KEY, value TEXT NOT NULL)`
+  )
+  db.run(
+    `INSERT INTO app_settings (key, value) VALUES ('schema_version', '40')`
+  )
+  db.run(`
+    CREATE TABLE transaction_user_data (
+      transaction_id TEXT PRIMARY KEY,
+      user_notes TEXT,
+      user_category_override TEXT,
+      is_income INTEGER DEFAULT 0
+    )
+  `)
+  db.run(
+    `INSERT INTO transaction_user_data (transaction_id, user_notes, user_category_override, is_income)
+     VALUES ('tx-1', 'note here', 'groceries', 1)`
+  )
+  return db
+}
+
+describe('v41 migration: drop dead transaction_user_data.is_income column', () => {
+  it('drops the column and preserves every other value on existing rows', () => {
+    const db = buildLegacyV40Database()
+
+    runMigrations(db)
+
+    expect(readSetting(db, 'schema_version')).toBe(String(SCHEMA_VERSION))
+
+    const cols = db.exec(`PRAGMA table_info(transaction_user_data)`)
+    const colNames = cols[0].values.map((r) => String(r[1]))
+    expect(colNames).not.toContain('is_income')
+    expect(colNames).toEqual(
+      expect.arrayContaining([
+        'transaction_id',
+        'user_notes',
+        'user_category_override',
+      ])
+    )
+
+    const row = db.exec(
+      `SELECT transaction_id, user_notes, user_category_override FROM transaction_user_data`
+    )
+    expect(row[0].values[0]).toEqual(['tx-1', 'note here', 'groceries'])
+
+    db.close()
+  })
+
+  it('is a no-op when the column is already gone, and is idempotent', () => {
+    const db = buildLegacyV40Database()
+    runMigrations(db)
+    expect(() => runMigrations(db)).not.toThrow()
     db.close()
   })
 })

--- a/src/db/schema.migration.test.ts
+++ b/src/db/schema.migration.test.ts
@@ -159,7 +159,7 @@ describe('v36 migration: bank-statement-import removal', () => {
       `SELECT value FROM app_settings WHERE key = 'schema_version'`
     )
     expect(versionRow[0].values[0][0]).toBe(String(SCHEMA_VERSION))
-    expect(SCHEMA_VERSION).toBe(41)
+    expect(SCHEMA_VERSION).toBe(42)
 
     // The credit-card-import account is gone.
     const ccAccount = db.exec(`SELECT * FROM accounts WHERE id = 'cc-visa'`)
@@ -720,6 +720,68 @@ describe('v41 migration: drop dead transaction_user_data.is_income column', () =
 
   it('is a no-op when the column is already gone, and is idempotent', () => {
     const db = buildLegacyV40Database()
+    runMigrations(db)
+    expect(() => runMigrations(db)).not.toThrow()
+    db.close()
+  })
+})
+
+/**
+ * Minimal v41-shaped fixture for the v42 migration, which drops the dead
+ * `accounts.monthly_deposit_target_cents` column (#28 — read into AccountRow but
+ * sync never wrote it and no UI surfaced it). Carries the column and one row.
+ */
+function buildLegacyV41Database(): Database {
+  const db = new SQL.Database()
+  db.run(
+    `CREATE TABLE app_settings (key TEXT PRIMARY KEY, value TEXT NOT NULL)`
+  )
+  db.run(
+    `INSERT INTO app_settings (key, value) VALUES ('schema_version', '41')`
+  )
+  db.run(`
+    CREATE TABLE accounts (
+      id TEXT PRIMARY KEY,
+      display_name TEXT NOT NULL,
+      account_type TEXT NOT NULL,
+      balance INTEGER NOT NULL,
+      created_at TEXT NOT NULL,
+      updated_at TEXT NOT NULL,
+      is_closed INTEGER NOT NULL DEFAULT 0,
+      target_amount_cents INTEGER,
+      monthly_deposit_target_cents INTEGER
+    )
+  `)
+  db.run(
+    `INSERT INTO accounts (id, display_name, account_type, balance, created_at, updated_at, target_amount_cents, monthly_deposit_target_cents)
+     VALUES ('sav-1', 'Holiday', 'SAVER', 500000, '2026-01-01', '2026-01-01', 1000000, 20000)`
+  )
+  return db
+}
+
+describe('v42 migration: drop dead accounts.monthly_deposit_target_cents column', () => {
+  it('drops the column and preserves every other value on existing rows', () => {
+    const db = buildLegacyV41Database()
+
+    runMigrations(db)
+
+    expect(readSetting(db, 'schema_version')).toBe(String(SCHEMA_VERSION))
+
+    const cols = db.exec(`PRAGMA table_info(accounts)`)
+    const colNames = cols[0].values.map((r) => String(r[1]))
+    expect(colNames).not.toContain('monthly_deposit_target_cents')
+    expect(colNames).toContain('target_amount_cents')
+
+    const row = db.exec(
+      `SELECT id, display_name, balance, target_amount_cents FROM accounts`
+    )
+    expect(row[0].values[0]).toEqual(['sav-1', 'Holiday', 500000, 1000000])
+
+    db.close()
+  })
+
+  it('is a no-op when the column is already gone, and is idempotent', () => {
+    const db = buildLegacyV41Database()
     runMigrations(db)
     expect(() => runMigrations(db)).not.toThrow()
     db.close()

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -5,7 +5,7 @@
 
 import type { Database } from 'sql.js'
 
-const SCHEMA_VERSION = 41
+const SCHEMA_VERSION = 42
 
 function tableExists(database: Database, name: string): boolean {
   const stmt = database.prepare(
@@ -29,7 +29,6 @@ const DDL_STATEMENTS = [
     synced_at TEXT,
     is_closed INTEGER NOT NULL DEFAULT 0,
     target_amount_cents INTEGER,
-    monthly_deposit_target_cents INTEGER,
     opening_balance_cents INTEGER,
     opening_balance_date TEXT
   )`,
@@ -1127,6 +1126,25 @@ export function runMigrations(database: Database): void {
     database.run(
       `INSERT OR REPLACE INTO app_settings (key, value) VALUES ('schema_version', ?)`,
       ['41']
+    )
+  }
+
+  // #28 — accounts.monthly_deposit_target_cents was added by an early migration
+  // and read into AccountRow, but sync never wrote it and no UI surfaced it. Any
+  // "how much am I saving" figure is derived from real transaction history. Drop it.
+  if (version < 42) {
+    const accCols = database.exec(`PRAGMA table_info(accounts)`)
+    const accHasMonthlyTarget = (accCols[0]?.values ?? []).some(
+      (r) => String(r[1]) === 'monthly_deposit_target_cents'
+    )
+    if (accHasMonthlyTarget) {
+      database.run(
+        `ALTER TABLE accounts DROP COLUMN monthly_deposit_target_cents`
+      )
+    }
+    database.run(
+      `INSERT OR REPLACE INTO app_settings (key, value) VALUES ('schema_version', ?)`,
+      ['42']
     )
   }
 }

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -5,7 +5,7 @@
 
 import type { Database } from 'sql.js'
 
-const SCHEMA_VERSION = 40
+const SCHEMA_VERSION = 41
 
 function tableExists(database: Database, name: string): boolean {
   const stmt = database.prepare(
@@ -144,7 +144,6 @@ const DDL_STATEMENTS = [
     transaction_id TEXT PRIMARY KEY,
     user_notes TEXT,
     user_category_override TEXT,
-    is_income INTEGER DEFAULT 0,
     FOREIGN KEY (transaction_id) REFERENCES transactions(id)
   )`,
   `CREATE TABLE IF NOT EXISTS future_items (
@@ -1111,6 +1110,23 @@ export function runMigrations(database: Database): void {
     database.run(
       `INSERT OR REPLACE INTO app_settings (key, value) VALUES ('schema_version', ?)`,
       ['40']
+    )
+  }
+
+  // #26 — transaction_user_data.is_income was added by an early migration but
+  // nothing in src/ ever read or wrote it: no "mark as income" UI, and the
+  // TransactionUserRow interface never carried it. Drop it.
+  if (version < 41) {
+    const tudCols = database.exec(`PRAGMA table_info(transaction_user_data)`)
+    const tudHasIsIncome = (tudCols[0]?.values ?? []).some(
+      (r) => String(r[1]) === 'is_income'
+    )
+    if (tudHasIsIncome) {
+      database.run(`ALTER TABLE transaction_user_data DROP COLUMN is_income`)
+    }
+    database.run(
+      `INSERT OR REPLACE INTO app_settings (key, value) VALUES ('schema_version', ?)`,
+      ['41']
     )
   }
 }

--- a/src/services/accounts.ts
+++ b/src/services/accounts.ts
@@ -12,7 +12,6 @@ export interface AccountRow {
   ownership_type: string | null
   is_closed: number
   target_amount_cents: number | null
-  monthly_deposit_target_cents: number | null
 }
 
 /**
@@ -29,7 +28,7 @@ export function getAccountsByTypes(
   const closedFilter = includeClosed ? '' : ' AND is_closed = 0'
   const stmt = db.prepare(
     `SELECT id, display_name, account_type, balance, ownership_type, is_closed,
-            target_amount_cents, monthly_deposit_target_cents
+            target_amount_cents
      FROM accounts WHERE account_type IN (${placeholders})${closedFilter}
      ORDER BY display_name COLLATE NOCASE`
   )
@@ -44,7 +43,6 @@ export function getAccountsByTypes(
       string | null,
       number,
       number | null,
-      number | null,
     ]
     out.push({
       id: r[0],
@@ -54,7 +52,6 @@ export function getAccountsByTypes(
       ownership_type: r[4],
       is_closed: r[5],
       target_amount_cents: r[6] ?? null,
-      monthly_deposit_target_cents: r[7] ?? null,
     })
   }
   stmt.free()
@@ -70,7 +67,7 @@ export function getAccountById(id: string): AccountRow | null {
   if (!db) return null
   const stmt = db.prepare(
     `SELECT id, display_name, account_type, balance, ownership_type, is_closed,
-            target_amount_cents, monthly_deposit_target_cents
+            target_amount_cents
      FROM accounts WHERE id = ?`
   )
   stmt.bind([id])
@@ -86,7 +83,6 @@ export function getAccountById(id: string): AccountRow | null {
     string | null,
     number,
     number | null,
-    number | null,
   ]
   stmt.free()
   return {
@@ -97,7 +93,6 @@ export function getAccountById(id: string): AccountRow | null {
     ownership_type: r[4],
     is_closed: r[5],
     target_amount_cents: r[6] ?? null,
-    monthly_deposit_target_cents: r[7] ?? null,
   }
 }
 


### PR DESCRIPTION
Part of #13's follow-on backlog — the contained "low-priority cleanups" batch. One commit per issue.

## #25 — Analytics comparison components: unreachable code (`a4cc872`)
- `AnalyticsAtAGlanceSection`: `getYearMonthlyTotals` returns exactly 12 points in every path (including the no-db early return), so the `pointsCurrent.length === 12 ? … : emptyYearPoints(12)` guards never take the else. Pass the arrays straight through; delete `emptyYearPoints`.
- `ComparisonNarratives`: the `narratives.length === 0 && priorLabel` "On track with {priorLabel}" branch is dead for every caller — both `AnalyticsAtAGlanceSection` and `MonthSummarySection` guard externally on `narratives.length > 0` and never pass `priorLabel`. Drop the branch and the prop; keep a cheap `length === 0 → null` guard.

## #26 — Drop dead `transaction_user_data.is_income` column (`b29c0c8`)
Added by an early migration but nothing in `src/` ever read or wrote it (no "mark as income" UI; `TransactionUserRow` never carried it). Mirrors the #21 `is_subscription` cleanup.
- schema **v41**: `ALTER TABLE … DROP COLUMN`, guarded on `PRAGMA table_info` (no-op where already absent); removed from create-table DDL.
- `profileExport` never touched this table, so no export-payload change.

## #28 — Drop dead `accounts.monthly_deposit_target_cents` column (`19e41eb`)
Read into `AccountRow` but sync never populated it and no UI surfaced it — any "how much am I saving" figure comes from real transaction history. Mirrors #21 and #26.
- schema **v42**: guarded `DROP COLUMN` + DDL.
- `accounts.ts`: removed from `AccountRow`, both SELECTs, and both tuple types / row mappings in `getAccountsByTypes` and `getAccountById`.

## Verification
- `npm run validate` clean.
- Full unit suite **418 passing**. Each migration adds a preserve-other-values test + an idempotency test; migration-canary bumped to 42.
- Schema version steps 40 → 41 → 42 cleanly across the three commits (merge without squashing to keep that, or squash — the final tree is the same).

## Docs
`docs/` is gitignored; the matching edits (`DATABASE.md`, `transactions/OVERVIEW.md`, `savers/OVERVIEW.md` — dropping the dead-column notes) are applied locally.

## Not included
**#31** (empty parent-category headers) — assessed only. `colorSystem.ts` has no runtime adjacency validation (colour is a static per-category-id family lookup), so empty headers add nothing mechanically; but dropping an empty middle group creates family adjacencies not present today, and confirming each is colour-blind-safe needs a CVD pass on the 6-family palette. Left for its own pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)