### PR TITLE
Export/import Net Worth manual accounts + history (#34)

### DIFF
--- a/src/pages/settings/ImportProfileModal.tsx
+++ b/src/pages/settings/ImportProfileModal.tsx
@@ -10,6 +10,7 @@ import {
   type UpcomingChargeExportRow,
   type BudgetBucketExportRow,
   type BudgetHypotheticalExportRow,
+  type ManualAccountExportRow,
   type ImportOptions,
 } from '@/services/profileExport'
 import { getPaydayDayLabel } from '@/lib/payday'
@@ -63,6 +64,15 @@ function formatBudgetSummary(
   return `${buckets.length} bucket${buckets.length !== 1 ? 's' : ''}, ${hypsArr.length} hypothetical${hypsArr.length !== 1 ? 's' : ''}`
 }
 
+function formatNetWorthSummary(
+  accounts: ManualAccountExportRow[] | undefined
+): string {
+  if (!Array.isArray(accounts) || accounts.length === 0) return 'None'
+  const names = accounts.slice(0, 3).map((a) => a.name)
+  const more = accounts.length > 3 ? ` +${accounts.length - 3} more` : ''
+  return `${accounts.length} manual account${accounts.length !== 1 ? 's' : ''} (${names.join(', ')}${more})`
+}
+
 export function ImportProfileModal() {
   const [show, setShow] = useState(false)
   const [file, setFile] = useState<File | null>(null)
@@ -79,6 +89,7 @@ export function ImportProfileModal() {
     trackers: true,
     upcomingCharges: true,
     budgetPlan: true,
+    netWorth: true,
   })
 
   function close() {
@@ -116,6 +127,10 @@ export function ImportProfileModal() {
         trackers: true,
         upcomingCharges: true,
         budgetPlan: true,
+        // Pre-v5 files carry no Net Worth section; only offer it (and only
+        // let it run) when the file actually contains one, so a replace-all
+        // can't wipe local manual accounts from an old export.
+        netWorth: payload.manualAccounts !== undefined,
       })
       setStep(2)
     } catch (err) {
@@ -205,8 +220,9 @@ export function ImportProfileModal() {
           <Form onSubmit={handleSubmit}>
             <Modal.Body id="import-modal-description">
               <p className="small text-muted mb-3">
-                Imports settings, trackers, upcoming charges, and budget plan
-                into this device. Will not import transactions or API tokens.
+                Imports settings, trackers, upcoming charges, budget plan, and
+                Net Worth manual accounts into this device. Will not import
+                transactions or API tokens.
               </p>
               <Form.Group className="mb-3">
                 <Form.Label>Settings file</Form.Label>
@@ -307,10 +323,11 @@ export function ImportProfileModal() {
             <Modal.Body id="import-modal-description">
               <p className="small text-muted mb-3">
                 Choose which sections to import. Each selected section fully
-                replaces the existing data on this device; unselected sections
-                are left unchanged. If you import Trackers or Upcoming charges
-                without importing Budget Plan, those items will lose their
-                bucket assignments.
+                replaces the existing data on this device — importing Net Worth
+                removes any manual account that isn't in the file — while
+                unselected sections are left unchanged. If you import Trackers
+                or Upcoming charges without importing Budget Plan, those items
+                will lose their bucket assignments.
               </p>
               {preview &&
                 (() => {
@@ -379,7 +396,7 @@ export function ImportProfileModal() {
                           {formatUpcomingSummary(preview.upcomingCharges ?? [])}
                         </div>
                       </div>
-                      <div>
+                      <div className={preview.manualAccounts ? 'mb-2' : ''}>
                         <Form.Check
                           type="checkbox"
                           id="import-opt-budget-plan"
@@ -407,6 +424,29 @@ export function ImportProfileModal() {
                           )}
                         </div>
                       </div>
+                      {preview.manualAccounts !== undefined && (
+                        <div>
+                          <Form.Check
+                            type="checkbox"
+                            id="import-opt-net-worth"
+                            label="Net Worth (manual accounts & history)"
+                            checked={options.netWorth}
+                            onChange={(e) =>
+                              setOptions((o) => ({
+                                ...o,
+                                netWorth: e.target.checked,
+                              }))
+                            }
+                            aria-label="Import Net Worth manual accounts and history"
+                          />
+                          <div className="small text-muted ms-4 mt-1">
+                            Current:{' '}
+                            {formatNetWorthSummary(current.manualAccounts)}
+                            {' → '}
+                            New: {formatNetWorthSummary(preview.manualAccounts)}
+                          </div>
+                        </div>
+                      )}
                     </div>
                   )
                 })()}
@@ -429,7 +469,8 @@ export function ImportProfileModal() {
                   (!options.settings &&
                     !options.trackers &&
                     !options.upcomingCharges &&
-                    !options.budgetPlan)
+                    !options.budgetPlan &&
+                    !options.netWorth)
                 }
                 aria-busy={importing}
               >

--- a/src/services/profileExport.test.ts
+++ b/src/services/profileExport.test.ts
@@ -12,6 +12,7 @@ import {
   replaceBudgetPlan,
   replaceTrackers,
   replaceUpcomingCharges,
+  replaceNetWorth,
   importPayloadWithOptions,
   IMPORT_ERROR_INVALID_FILE,
   IMPORT_ERROR_WRONG_PASSPHRASE,
@@ -21,6 +22,8 @@ import {
   type TrackerExportRow,
   type TrackerConfigHistoryExportRow,
   type UpcomingChargeExportRow,
+  type ManualAccountExportRow,
+  type NetWorthSnapshotExportRow,
 } from './profileExport'
 
 vi.mock('@/db', () => ({
@@ -511,6 +514,7 @@ describe('profile import writers: real-DB coverage (#36)', () => {
     trackers: true,
     upcomingCharges: true,
     budgetPlan: true,
+    netWorth: true,
   }
 
   function readTrackers(): Array<{
@@ -885,6 +889,7 @@ describe('profile import writers: real-DB coverage (#36)', () => {
           trackers: false,
           upcomingCharges: false,
           budgetPlan: false,
+          netWorth: false,
         }
       )
 
@@ -903,6 +908,7 @@ describe('profile import writers: real-DB coverage (#36)', () => {
           trackers: true,
           upcomingCharges: true,
           budgetPlan: false,
+          netWorth: false,
         }
       )
 
@@ -1035,6 +1041,352 @@ describe('profile import writers: real-DB coverage (#36)', () => {
       // Transaction was closed by COMMIT, not left dangling.
       expect(() => realDb.run('BEGIN')).not.toThrow()
       realDb.run('ROLLBACK')
+    })
+  })
+
+  // ── #34: Net Worth (manual_accounts + net_worth_snapshots) ─────────────
+
+  describe('Net Worth export/import (#34)', () => {
+    function insertManualAccount(over: Partial<Record<string, unknown>> = {}) {
+      const row = {
+        name: 'Mortgage',
+        institution: 'Big Bank',
+        account_type: 'MORTGAGE',
+        kind: 'liability',
+        balance_cents: 45000000,
+        credit_limit_cents: null,
+        interest_rate_bps: 599,
+        rate_type: 'variable',
+        fixed_rate_expiry_date: null,
+        notes: 'offset linked',
+        sort_order: 0,
+        last_updated_at: '2026-02-10T00:00:00.000Z',
+        created_at: '2026-01-01T00:00:00.000Z',
+        ...over,
+      }
+      realDb.run(
+        `INSERT INTO manual_accounts
+           (name, institution, account_type, kind, balance_cents, credit_limit_cents,
+            interest_rate_bps, rate_type, fixed_rate_expiry_date, notes, sort_order,
+            last_updated_at, created_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+        [
+          row.name,
+          row.institution,
+          row.account_type,
+          row.kind,
+          row.balance_cents,
+          row.credit_limit_cents,
+          row.interest_rate_bps,
+          row.rate_type,
+          row.fixed_rate_expiry_date,
+          row.notes,
+          row.sort_order,
+          row.last_updated_at,
+          row.created_at,
+        ] as never[]
+      )
+    }
+
+    function insertSnapshot(
+      date: string,
+      up = 100000,
+      assets = 0,
+      liabilities = 0
+    ) {
+      realDb.run(
+        `INSERT INTO net_worth_snapshots (snapshot_date, up_bank_cents, manual_assets_cents, manual_liabilities_cents)
+         VALUES (?, ?, ?, ?)`,
+        [date, up, assets, liabilities]
+      )
+    }
+
+    function readManualAccounts() {
+      const stmt = realDb.prepare(
+        `SELECT name, account_type, kind, balance_cents, interest_rate_bps, notes,
+                sort_order, last_updated_at, created_at
+         FROM manual_accounts ORDER BY sort_order, id`
+      )
+      const out: Array<Record<string, unknown>> = []
+      while (stmt.step()) {
+        const r = stmt.get() as [
+          string,
+          string,
+          string,
+          number,
+          number | null,
+          string | null,
+          number,
+          string,
+          string,
+        ]
+        out.push({
+          name: r[0],
+          account_type: r[1],
+          kind: r[2],
+          balance_cents: r[3],
+          interest_rate_bps: r[4],
+          notes: r[5],
+          sort_order: r[6],
+          last_updated_at: r[7],
+          created_at: r[8],
+        })
+      }
+      stmt.free()
+      return out
+    }
+
+    function readSnapshots() {
+      const stmt = realDb.prepare(
+        `SELECT snapshot_date, up_bank_cents, manual_assets_cents, manual_liabilities_cents
+         FROM net_worth_snapshots ORDER BY snapshot_date`
+      )
+      const out: Array<[string, number, number, number]> = []
+      while (stmt.step())
+        out.push(stmt.get() as [string, number, number, number])
+      stmt.free()
+      return out
+    }
+
+    it('buildExportPayload carries manual_accounts (minus id) and net_worth_snapshots', () => {
+      insertManualAccount({ name: 'Mortgage' })
+      insertManualAccount({
+        name: 'Shares',
+        account_type: 'INVESTMENT',
+        kind: 'asset',
+        sort_order: 1,
+      })
+      insertSnapshot('2026-02-01', 500000, 10000, 45000000)
+
+      const payload = buildExportPayload()
+
+      expect(payload.version).toBe(5)
+      expect(payload.manualAccounts?.map((a) => a.name)).toEqual([
+        'Mortgage',
+        'Shares',
+      ])
+      expect(payload.manualAccounts?.[0]).not.toHaveProperty('id')
+      expect(payload.manualAccounts?.[0]).toMatchObject({
+        account_type: 'MORTGAGE',
+        kind: 'liability',
+        balance_cents: 45000000,
+        interest_rate_bps: 599,
+        last_updated_at: '2026-02-10T00:00:00.000Z',
+        created_at: '2026-01-01T00:00:00.000Z',
+      })
+      expect(payload.netWorthSnapshots).toEqual([
+        {
+          snapshot_date: '2026-02-01',
+          up_bank_cents: 500000,
+          manual_assets_cents: 10000,
+          manual_liabilities_cents: 45000000,
+        },
+      ])
+    })
+
+    it('replaceNetWorth wipes both tables and reinserts, preserving exported timestamps', () => {
+      insertManualAccount({ name: 'Stale local account' })
+      insertSnapshot('2025-12-31')
+
+      const accounts: ManualAccountExportRow[] = [
+        {
+          name: 'Imported Mortgage',
+          institution: null,
+          account_type: 'MORTGAGE',
+          kind: 'liability',
+          balance_cents: 30000000,
+          credit_limit_cents: null,
+          interest_rate_bps: 610,
+          rate_type: 'fixed',
+          fixed_rate_expiry_date: '2027-06-30',
+          notes: null,
+          sort_order: 0,
+          last_updated_at: '2026-02-14T00:00:00.000Z',
+          created_at: '2025-08-01T00:00:00.000Z',
+        },
+      ]
+      replaceNetWorth(accounts, [
+        {
+          snapshot_date: '2026-02-14',
+          up_bank_cents: 1234,
+          manual_assets_cents: 0,
+          manual_liabilities_cents: 30000000,
+        },
+      ])
+
+      expect(readManualAccounts()).toEqual([
+        {
+          name: 'Imported Mortgage',
+          account_type: 'MORTGAGE',
+          kind: 'liability',
+          balance_cents: 30000000,
+          interest_rate_bps: 610,
+          notes: null,
+          sort_order: 0,
+          last_updated_at: '2026-02-14T00:00:00.000Z',
+          created_at: '2025-08-01T00:00:00.000Z',
+        },
+      ])
+      expect(readSnapshots()).toEqual([['2026-02-14', 1234, 0, 30000000]])
+    })
+
+    it('replaceNetWorth with empty arrays clears both tables', () => {
+      insertManualAccount()
+      insertSnapshot('2026-01-15')
+
+      replaceNetWorth([], [])
+
+      expect(readManualAccounts()).toEqual([])
+      expect(readSnapshots()).toEqual([])
+    })
+
+    it('replaceNetWorth skips structurally invalid account and snapshot rows', () => {
+      replaceNetWorth(
+        [
+          {
+            name: '',
+            account_type: 'X',
+            kind: 'asset',
+            balance_cents: 1,
+          } as ManualAccountExportRow,
+          {
+            name: 'NoBalance',
+            account_type: 'X',
+            kind: 'asset',
+          } as unknown as ManualAccountExportRow,
+          {
+            name: 'BadKind',
+            institution: null,
+            account_type: 'SAVINGS',
+            kind: 'wealth' as unknown as 'asset',
+            balance_cents: 100,
+            credit_limit_cents: null,
+            interest_rate_bps: null,
+            rate_type: null,
+            fixed_rate_expiry_date: null,
+            notes: null,
+            sort_order: 0,
+            last_updated_at: '2026-02-01T00:00:00.000Z',
+            created_at: '2026-02-01T00:00:00.000Z',
+          },
+          {
+            name: 'Good',
+            institution: null,
+            account_type: 'SAVINGS',
+            kind: 'asset',
+            balance_cents: 5000,
+            credit_limit_cents: null,
+            interest_rate_bps: null,
+            rate_type: null,
+            fixed_rate_expiry_date: null,
+            notes: null,
+            sort_order: 0,
+            last_updated_at: '2026-02-01T00:00:00.000Z',
+            created_at: '2026-02-01T00:00:00.000Z',
+          },
+        ],
+        [
+          {
+            snapshot_date: 'bad',
+            up_bank_cents: 1,
+            manual_assets_cents: 0,
+            manual_liabilities_cents: 0,
+          } as NetWorthSnapshotExportRow,
+          {
+            snapshot_date: '2026-02-01',
+            up_bank_cents: 9,
+            manual_assets_cents: 0,
+            manual_liabilities_cents: 0,
+          },
+        ]
+      )
+
+      expect(readManualAccounts().map((a) => a.name)).toEqual(['Good'])
+      expect(readSnapshots()).toEqual([['2026-02-01', 9, 0, 0]])
+    })
+
+    it('importPayloadWithOptions honours the netWorth toggle', () => {
+      insertManualAccount({ name: 'Keep when off' })
+
+      // netWorth: false → existing manual account untouched
+      importPayloadWithOptions(
+        emptyPayload({
+          manualAccounts: [
+            {
+              name: 'Should not appear',
+              institution: null,
+              account_type: 'SAVINGS',
+              kind: 'asset',
+              balance_cents: 1,
+              credit_limit_cents: null,
+              interest_rate_bps: null,
+              rate_type: null,
+              fixed_rate_expiry_date: null,
+              notes: null,
+              sort_order: 0,
+              last_updated_at: '2026-02-01T00:00:00.000Z',
+              created_at: '2026-02-01T00:00:00.000Z',
+            },
+          ],
+        }),
+        { ...ALL_ON, netWorth: false }
+      )
+      expect(readManualAccounts().map((a) => a.name)).toEqual(['Keep when off'])
+
+      // netWorth: true → replaced
+      importPayloadWithOptions(
+        emptyPayload({
+          manualAccounts: [
+            {
+              name: 'Imported',
+              institution: null,
+              account_type: 'SAVINGS',
+              kind: 'asset',
+              balance_cents: 2,
+              credit_limit_cents: null,
+              interest_rate_bps: null,
+              rate_type: null,
+              fixed_rate_expiry_date: null,
+              notes: null,
+              sort_order: 0,
+              last_updated_at: '2026-02-01T00:00:00.000Z',
+              created_at: '2026-02-01T00:00:00.000Z',
+            },
+          ],
+          netWorthSnapshots: [
+            {
+              snapshot_date: '2026-02-01',
+              up_bank_cents: 3,
+              manual_assets_cents: 2,
+              manual_liabilities_cents: 0,
+            },
+          ],
+        }),
+        ALL_ON
+      )
+      expect(readManualAccounts().map((a) => a.name)).toEqual(['Imported'])
+      expect(readSnapshots()).toEqual([['2026-02-01', 3, 2, 0]])
+    })
+
+    it('the wizard gate (netWorth = manualAccounts !== undefined) spares Net Worth data on a pre-v5 file', () => {
+      insertManualAccount({ name: 'Pre-existing' })
+      insertSnapshot('2026-01-01')
+
+      // A v4 payload has no manualAccounts / netWorthSnapshots key at all.
+      // `netWorth: true` would then run replaceNetWorth([], []) and wipe both
+      // tables — same "selected section replaces with what the file has"
+      // contract as every other section. The wizard's gate is what stops that:
+      // it only sets netWorth when the file actually contains the section.
+      const v4Payload = emptyPayload()
+      expect(v4Payload.manualAccounts).toBeUndefined()
+
+      importPayloadWithOptions(v4Payload, {
+        ...ALL_ON,
+        netWorth: v4Payload.manualAccounts !== undefined,
+      })
+
+      expect(readManualAccounts().map((a) => a.name)).toEqual(['Pre-existing'])
+      expect(readSnapshots()).toEqual([['2026-01-01', 100000, 0, 0]])
     })
   })
 })

--- a/src/services/profileExport.test.ts
+++ b/src/services/profileExport.test.ts
@@ -1368,25 +1368,38 @@ describe('profile import writers: real-DB coverage (#36)', () => {
       expect(readSnapshots()).toEqual([['2026-02-01', 3, 2, 0]])
     })
 
-    it('the wizard gate (netWorth = manualAccounts !== undefined) spares Net Worth data on a pre-v5 file', () => {
+    it('netWorth: true on a pre-v5 payload (no Net Worth section) is a no-op, not a wipe', () => {
       insertManualAccount({ name: 'Pre-existing' })
       insertSnapshot('2026-01-01')
 
       // A v4 payload has no manualAccounts / netWorthSnapshots key at all.
-      // `netWorth: true` would then run replaceNetWorth([], []) and wipe both
-      // tables — same "selected section replaces with what the file has"
-      // contract as every other section. The wizard's gate is what stops that:
-      // it only sets netWorth when the file actually contains the section.
+      // Without the `manualAccounts !== undefined` guard in
+      // importPayloadWithOptions, `netWorth: true` would run
+      // replaceNetWorth([], []) and DELETE both tables with nothing to
+      // reinsert. The guard makes an absent section a skip regardless of
+      // caller — the wizard no longer has to be the only thing stopping it.
       const v4Payload = emptyPayload()
       expect(v4Payload.manualAccounts).toBeUndefined()
 
-      importPayloadWithOptions(v4Payload, {
-        ...ALL_ON,
-        netWorth: v4Payload.manualAccounts !== undefined,
-      })
+      importPayloadWithOptions(v4Payload, { ...ALL_ON, netWorth: true })
 
       expect(readManualAccounts().map((a) => a.name)).toEqual(['Pre-existing'])
       expect(readSnapshots()).toEqual([['2026-01-01', 100000, 0, 0]])
+    })
+
+    it('netWorth: true with an explicitly empty manualAccounts still clears both tables', () => {
+      insertManualAccount({ name: 'Wiped' })
+      insertSnapshot('2026-01-01')
+
+      // `manualAccounts: []` is a present-but-empty section: a real replace-all
+      // that intentionally clears the device, distinct from an absent section.
+      importPayloadWithOptions(emptyPayload({ manualAccounts: [] }), {
+        ...ALL_ON,
+        netWorth: true,
+      })
+
+      expect(readManualAccounts()).toEqual([])
+      expect(readSnapshots()).toEqual([])
     })
   })
 })

--- a/src/services/profileExport.ts
+++ b/src/services/profileExport.ts
@@ -1,7 +1,10 @@
 /**
- * Profile export/import: encrypted file-based transfer of non-sensitive
- * settings, trackers, upcoming charges, and budget plan between devices.
- * Never exports transactions, accounts, API tokens, or keys.
+ * Profile export/import: encrypted file-based transfer of settings, trackers,
+ * upcoming charges, budget plan, and Net Worth manual accounts + snapshot
+ * history between devices. Never exports Up Bank transactions or accounts, the
+ * API token, or encryption keys. The manual-account balances / institution
+ * names / notes that #34 added are only ever written to the passphrase-encrypted
+ * bundle and stay on-device — nothing here makes a network call.
  */
 
 import { getDb, getAppSetting, setAppSetting, schedulePersist } from '@/db'
@@ -16,7 +19,7 @@ import { SCHEMA_VERSION } from '@/db/schema'
 import { writeTrackerConfigVersion } from './trackers'
 
 /** Export format version for the encrypted payload */
-const EXPORT_PAYLOAD_VERSION = 4
+const EXPORT_PAYLOAD_VERSION = 5
 
 /** File wrapper version for the outer JSON structure */
 const EXPORT_FILE_VERSION = 1
@@ -73,6 +76,10 @@ export interface ExportPayload {
   upcomingCharges: UpcomingChargeExportRow[]
   budgetBuckets: BudgetBucketExportRow[]
   budgetHypotheticals: BudgetHypotheticalExportRow[]
+  /** #34 — Net Worth manual accounts. Absent in payloads from before v5. */
+  manualAccounts?: ManualAccountExportRow[]
+  /** #34 — Net Worth daily snapshot history. Absent in payloads from before v5. */
+  netWorthSnapshots?: NetWorthSnapshotExportRow[]
 }
 
 export interface TrackerExportRow {
@@ -120,6 +127,37 @@ export interface BudgetHypotheticalExportRow {
   amount_cents: number
   frequency: string
   is_hypothetical: number
+}
+
+/**
+ * #34 — a `manual_accounts` row minus its local AUTOINCREMENT `id` (no
+ * cross-database identity, same as `upcoming_charges`). `last_updated_at` and
+ * `created_at` are carried through as-exported rather than reset on import — a
+ * restored account should report when its balance was actually last confirmed.
+ */
+export interface ManualAccountExportRow {
+  name: string
+  institution: string | null
+  account_type: string
+  kind: string
+  balance_cents: number
+  credit_limit_cents: number | null
+  interest_rate_bps: number | null
+  rate_type: string | null
+  fixed_rate_expiry_date: string | null
+  notes: string | null
+  sort_order: number
+  last_updated_at: string
+  created_at: string
+}
+
+/** #34 — a `net_worth_snapshots` row verbatim; `snapshot_date` is the PK and is
+ * itself cross-database stable, so no id remap is needed. */
+export interface NetWorthSnapshotExportRow {
+  snapshot_date: string
+  up_bank_cents: number
+  manual_assets_cents: number
+  manual_liabilities_cents: number
 }
 
 export interface ExportFileWrapper {
@@ -322,6 +360,73 @@ function collectBudgetHypotheticals(): BudgetHypotheticalExportRow[] {
   return rows
 }
 
+function collectManualAccounts(): ManualAccountExportRow[] {
+  const db = getDb()
+  if (!db) return []
+  const stmt = db.prepare(
+    `SELECT name, institution, account_type, kind, balance_cents,
+            credit_limit_cents, interest_rate_bps, rate_type,
+            fixed_rate_expiry_date, notes, sort_order, last_updated_at, created_at
+     FROM manual_accounts ORDER BY sort_order, id`
+  )
+  const rows: ManualAccountExportRow[] = []
+  while (stmt.step()) {
+    const r = stmt.get() as [
+      string,
+      string | null,
+      string,
+      string,
+      number,
+      number | null,
+      number | null,
+      string | null,
+      string | null,
+      string | null,
+      number,
+      string,
+      string,
+    ]
+    rows.push({
+      name: r[0],
+      institution: r[1],
+      account_type: r[2],
+      kind: r[3],
+      balance_cents: r[4],
+      credit_limit_cents: r[5],
+      interest_rate_bps: r[6],
+      rate_type: r[7],
+      fixed_rate_expiry_date: r[8],
+      notes: r[9],
+      sort_order: r[10],
+      last_updated_at: r[11],
+      created_at: r[12],
+    })
+  }
+  stmt.free()
+  return rows
+}
+
+function collectNetWorthSnapshots(): NetWorthSnapshotExportRow[] {
+  const db = getDb()
+  if (!db) return []
+  const stmt = db.prepare(
+    `SELECT snapshot_date, up_bank_cents, manual_assets_cents, manual_liabilities_cents
+     FROM net_worth_snapshots ORDER BY snapshot_date`
+  )
+  const rows: NetWorthSnapshotExportRow[] = []
+  while (stmt.step()) {
+    const r = stmt.get() as [string, number, number, number]
+    rows.push({
+      snapshot_date: r[0],
+      up_bank_cents: r[1],
+      manual_assets_cents: r[2],
+      manual_liabilities_cents: r[3],
+    })
+  }
+  stmt.free()
+  return rows
+}
+
 /**
  * Build the plain-text export payload (before encryption).
  */
@@ -333,6 +438,8 @@ export function buildExportPayload(): ExportPayload {
   const upcomingCharges = collectUpcomingCharges()
   const budgetBuckets = collectBudgetBuckets()
   const budgetHypotheticals = collectBudgetHypotheticals()
+  const manualAccounts = collectManualAccounts()
+  const netWorthSnapshots = collectNetWorthSnapshots()
 
   return {
     version: EXPORT_PAYLOAD_VERSION,
@@ -345,6 +452,8 @@ export function buildExportPayload(): ExportPayload {
     upcomingCharges,
     budgetBuckets,
     budgetHypotheticals,
+    manualAccounts,
+    netWorthSnapshots,
   }
 }
 
@@ -487,6 +596,8 @@ export interface ImportOptions {
   trackers: boolean
   upcomingCharges: boolean
   budgetPlan: boolean
+  /** #34 — manual_accounts + net_worth_snapshots (Net Worth). */
+  netWorth: boolean
 }
 
 /** Apply whitelisted settings from payload. */
@@ -784,6 +895,94 @@ export function replaceUpcomingCharges(
 }
 
 /**
+ * #34 — Replace manual_accounts and net_worth_snapshots with imported data.
+ * Both are full delete-then-reinsert (ADR-0013). manual_accounts.id is local
+ * AUTOINCREMENT so it is dropped on export and regenerated here; nothing
+ * references it across the export boundary. net_worth_snapshots carry no
+ * manual-account foreign keys — they are pre-aggregated daily totals keyed by
+ * date — so they just copy across.
+ */
+export function replaceNetWorth(
+  manualAccounts: ManualAccountExportRow[] = [],
+  netWorthSnapshots: NetWorthSnapshotExportRow[] = []
+): void {
+  const db = getDb()
+  if (!db) throw new Error('Database not ready')
+  db.run(`DELETE FROM net_worth_snapshots`)
+  db.run(`DELETE FROM manual_accounts`)
+
+  const now = new Date().toISOString()
+  const accounts = Array.isArray(manualAccounts) ? manualAccounts : []
+  for (const a of accounts) {
+    if (
+      typeof a.name !== 'string' ||
+      a.name === '' ||
+      typeof a.account_type !== 'string' ||
+      (a.kind !== 'asset' && a.kind !== 'liability') ||
+      typeof a.balance_cents !== 'number'
+    ) {
+      continue
+    }
+    const str = (v: unknown): string | null =>
+      typeof v === 'string' && v !== '' ? v : null
+    const num = (v: unknown): number | null =>
+      typeof v === 'number' ? v : null
+    const lastUpdatedAt =
+      typeof a.last_updated_at === 'string' && a.last_updated_at
+        ? a.last_updated_at
+        : now
+    const createdAt =
+      typeof a.created_at === 'string' && a.created_at ? a.created_at : now
+    db.run(
+      `INSERT INTO manual_accounts
+         (name, institution, account_type, kind, balance_cents, credit_limit_cents,
+          interest_rate_bps, rate_type, fixed_rate_expiry_date, notes, sort_order,
+          last_updated_at, created_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      [
+        a.name,
+        str(a.institution),
+        a.account_type,
+        a.kind,
+        a.balance_cents,
+        num(a.credit_limit_cents),
+        num(a.interest_rate_bps),
+        str(a.rate_type),
+        str(a.fixed_rate_expiry_date),
+        str(a.notes),
+        typeof a.sort_order === 'number' ? a.sort_order : 0,
+        lastUpdatedAt,
+        createdAt,
+      ]
+    )
+  }
+
+  const snapshots = Array.isArray(netWorthSnapshots) ? netWorthSnapshots : []
+  for (const s of snapshots) {
+    if (
+      typeof s.snapshot_date !== 'string' ||
+      s.snapshot_date.length < 10 ||
+      typeof s.up_bank_cents !== 'number' ||
+      typeof s.manual_assets_cents !== 'number' ||
+      typeof s.manual_liabilities_cents !== 'number'
+    ) {
+      continue
+    }
+    db.run(
+      `INSERT OR REPLACE INTO net_worth_snapshots
+         (snapshot_date, up_bank_cents, manual_assets_cents, manual_liabilities_cents)
+       VALUES (?, ?, ?, ?)`,
+      [
+        s.snapshot_date.slice(0, 10),
+        s.up_bank_cents,
+        s.manual_assets_cents,
+        s.manual_liabilities_cents,
+      ]
+    )
+  }
+}
+
+/**
  * Import payload into the database with optional section selection.
  * Budget plan is applied first so bucket IDs can be remapped for trackers
  * and upcoming charges.
@@ -831,6 +1030,12 @@ export function importPayloadWithOptions(
     }
     if (options.upcomingCharges) {
       replaceUpcomingCharges(payload.upcomingCharges ?? [], bucketIdMap)
+    }
+    if (options.netWorth) {
+      replaceNetWorth(
+        payload.manualAccounts ?? [],
+        payload.netWorthSnapshots ?? []
+      )
     }
 
     db.run('COMMIT')

--- a/src/services/profileExport.ts
+++ b/src/services/profileExport.ts
@@ -1031,11 +1031,15 @@ export function importPayloadWithOptions(
     if (options.upcomingCharges) {
       replaceUpcomingCharges(payload.upcomingCharges ?? [], bucketIdMap)
     }
-    if (options.netWorth) {
-      replaceNetWorth(
-        payload.manualAccounts ?? [],
-        payload.netWorthSnapshots ?? []
-      )
+    // A pre-v5 payload has no Net Worth section at all. Running replaceNetWorth
+    // then would DELETE both tables with nothing to reinsert, silently wiping
+    // this device's manual accounts and history. The wizard already only sets
+    // `netWorth` when the file contains the section, but gate it here too so no
+    // other caller (batch restore, tests, a future CLI) can trip the same
+    // footgun. `manualAccounts: []` — present but empty — is still a real
+    // replace-all and is left to run.
+    if (options.netWorth && payload.manualAccounts !== undefined) {
+      replaceNetWorth(payload.manualAccounts, payload.netWorthSnapshots ?? [])
     }
 
     db.run('COMMIT')


### PR DESCRIPTION
Closes #34. Final piece of #13's profile-data cluster. **Stacked on PR #40** (`test/36-profile-import-db-tests`, #35+#36) — review/merge that first; this branch's diff is only the #34 commit.

## Problem
Profile export bundled settings, trackers, upcoming charges and the budget plan but **not** `manual_accounts` or `net_worth_snapshots`. Restoring on a new device silently lost every manually-tracked account (mortgage, super, HECS, investments, property, credit cards) and the entire Net Worth history chart.

## Decisions (agreed up front)
- **Import model:** replace-all (delete + reinsert), consistent with ADR-0013 and the other `replace*` writers. Its own checkbox with a "Current → New" summary.
- **Snapshots:** bundled with manual accounts under one "Net Worth" toggle.
- **Old files:** payload `v4 → v5`; the new section is optional. An absent Net Worth section is treated as "skip", so a replace-all can't wipe local manual accounts from a pre-v5 export — enforced in `importPayloadWithOptions` itself (see "Review fix" below), with the wizard also hiding the checkbox. Otherwise defaults checked like every other section.
- `last_updated_at` / `created_at` carried through **as-exported** (truthful about when a balance was last confirmed), not reset to import time.

## Changes
- `ExportPayload` gains optional `manualAccounts` / `netWorthSnapshots`; `EXPORT_PAYLOAD_VERSION` → 5. `manual_accounts` drop their local AUTOINCREMENT `id` (like `upcoming_charges`); `net_worth_snapshots` copy verbatim (date-keyed, no manual-account FKs).
- `replaceNetWorth()` — delete-then-reinsert both tables with per-field `typeof` guards; `kind` must be `'asset' | 'liability'`. Runs inside `importPayloadWithOptions`'s transaction (#35).
- `ImportOptions.netWorth`; wizard checkbox + summary + step-1/step-2 copy.
- Top-of-file docstring updated: manual-account balances / institution names / notes now go in the (passphrase-encrypted, on-device) bundle; still no network call, still never exports Up transactions/accounts/token/keys.

## Review fix — pre-v5 wipe guard moved into `importPayloadWithOptions`
Original design put the pre-v5 protection only in the wizard (`netWorth: payload.manualAccounts !== undefined`). Any other caller passing `netWorth: true` with an absent section (batch restore, tests, a future CLI) would still run `replaceNetWorth([], [])` and `DELETE` both tables. `importPayloadWithOptions` now skips the section when `payload.manualAccounts === undefined`, so the protection holds regardless of caller. `manualAccounts: []` (present but empty) stays a real replace-all.

## Tests (full suite green)
`buildExportPayload` v5 shape with `id` dropped; `replaceNetWorth` wipe+reinsert with timestamp preservation, empty-clears-both, invalid-row skipping (incl. bad `kind`); `importPayloadWithOptions` `netWorth` gating; `netWorth: true` on a pre-v5 payload is a no-op (not a wipe); `netWorth: true` with explicit `manualAccounts: []` still clears both tables.

## Docs (gitignored, to follow with confirmation)
`profile-data/OVERVIEW.md` table + "Never exported" line, `docs/adr/0013`, `net-worth/OVERVIEW.md` + `savers/OVERVIEW.md` #34 notes.

## Verification
`npm run validate` clean; `profileExport.test.ts` 48 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
