### PR TITLE
Extract shared upsertUserDataField helper in transactionUserData.ts (#6)

### DIFF
--- a/src/services/transactionUserData.test.ts
+++ b/src/services/transactionUserData.test.ts
@@ -1,0 +1,175 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import initSqlJs, { type Database, type SqlJsStatic } from 'sql.js'
+import {
+  getTransactionUserData,
+  setTransactionUserNote,
+  setTransactionUserCategoryOverride,
+} from './transactionUserData'
+
+vi.mock('@/db', () => ({
+  getDb: vi.fn(),
+  schedulePersist: vi.fn(),
+}))
+
+/**
+ * #6 — real-DB coverage for the setters, whose four-way branch
+ * (clear-one-keep-sibling / delete-when-both-empty / update / insert) is now
+ * shared through the private `upsertUserDataField` helper. These assert both
+ * exports still behave identically after the extraction.
+ */
+describe('transactionUserData setters', () => {
+  let SQL: SqlJsStatic
+  let realDb: Database
+
+  beforeEach(async () => {
+    SQL = await initSqlJs()
+    const { runSchema } = await import('@/db/schema')
+    realDb = new SQL.Database()
+    runSchema(realDb)
+
+    const db = await import('@/db')
+    vi.mocked(db.getDb).mockReturnValue(realDb as never)
+    vi.mocked(db.schedulePersist).mockImplementation(() => {})
+  })
+
+  function rawRow(transactionId: string): {
+    user_notes: string | null
+    user_category_override: string | null
+  } | null {
+    const stmt = realDb.prepare(
+      `SELECT user_notes, user_category_override FROM transaction_user_data WHERE transaction_id = ?`
+    )
+    stmt.bind([transactionId])
+    if (!stmt.step()) {
+      stmt.free()
+      return null
+    }
+    const r = stmt.get() as [string | null, string | null]
+    stmt.free()
+    return { user_notes: r[0], user_category_override: r[1] }
+  }
+
+  // ── setTransactionUserNote ─────────────────────────────────────────────
+
+  it('inserts a row when setting a note on an untouched transaction', () => {
+    setTransactionUserNote('tx-1', 'remember this')
+    expect(rawRow('tx-1')).toEqual({
+      user_notes: 'remember this',
+      user_category_override: null,
+    })
+  })
+
+  it('trims the note and treats whitespace-only as a clear', () => {
+    setTransactionUserNote('tx-1', '  padded  ')
+    expect(rawRow('tx-1')?.user_notes).toBe('padded')
+
+    setTransactionUserNote('tx-1', '   ')
+    expect(rawRow('tx-1')).toBeNull()
+  })
+
+  it('updates an existing row when the note changes', () => {
+    setTransactionUserNote('tx-1', 'first')
+    setTransactionUserNote('tx-1', 'second')
+    expect(rawRow('tx-1')).toEqual({
+      user_notes: 'second',
+      user_category_override: null,
+    })
+  })
+
+  it('clearing the note keeps the row when a category override is still set', () => {
+    setTransactionUserCategoryOverride('tx-1', 'cat-groceries')
+    setTransactionUserNote('tx-1', 'temp note')
+    setTransactionUserNote('tx-1', null)
+    expect(rawRow('tx-1')).toEqual({
+      user_notes: null,
+      user_category_override: 'cat-groceries',
+    })
+  })
+
+  it('clearing the note deletes the row when nothing else is set', () => {
+    setTransactionUserNote('tx-1', 'temp note')
+    setTransactionUserNote('tx-1', null)
+    expect(rawRow('tx-1')).toBeNull()
+  })
+
+  it('clearing the note on an untouched transaction is a no-op', () => {
+    setTransactionUserNote('tx-1', null)
+    expect(rawRow('tx-1')).toBeNull()
+  })
+
+  // ── setTransactionUserCategoryOverride ────────────────────────────────
+
+  it('inserts a row when setting a category override on an untouched transaction', () => {
+    setTransactionUserCategoryOverride('tx-2', 'cat-rent')
+    expect(rawRow('tx-2')).toEqual({
+      user_notes: null,
+      user_category_override: 'cat-rent',
+    })
+  })
+
+  it('does not trim the category id', () => {
+    setTransactionUserCategoryOverride('tx-2', ' cat-with-space ')
+    expect(rawRow('tx-2')?.user_category_override).toBe(' cat-with-space ')
+  })
+
+  it('updates an existing row when the category override changes', () => {
+    setTransactionUserCategoryOverride('tx-2', 'cat-a')
+    setTransactionUserCategoryOverride('tx-2', 'cat-b')
+    expect(rawRow('tx-2')).toEqual({
+      user_notes: null,
+      user_category_override: 'cat-b',
+    })
+  })
+
+  it('clearing the category override keeps the row when a note is still set', () => {
+    setTransactionUserNote('tx-2', 'keep me')
+    setTransactionUserCategoryOverride('tx-2', 'cat-temp')
+    setTransactionUserCategoryOverride('tx-2', '')
+    expect(rawRow('tx-2')).toEqual({
+      user_notes: 'keep me',
+      user_category_override: null,
+    })
+  })
+
+  it('clearing the category override deletes the row when nothing else is set', () => {
+    setTransactionUserCategoryOverride('tx-2', 'cat-temp')
+    setTransactionUserCategoryOverride('tx-2', null)
+    expect(rawRow('tx-2')).toBeNull()
+  })
+
+  it('treats null and empty-string category ids identically as a clear', () => {
+    setTransactionUserCategoryOverride('tx-a', 'x')
+    setTransactionUserCategoryOverride('tx-a', null)
+    setTransactionUserCategoryOverride('tx-b', 'x')
+    setTransactionUserCategoryOverride('tx-b', '')
+    expect(rawRow('tx-a')).toBeNull()
+    expect(rawRow('tx-b')).toBeNull()
+  })
+
+  // ── both fields together ─────────────────────────────────────────────
+
+  it('keeps note and category override independent on one row', () => {
+    setTransactionUserNote('tx-3', 'a note')
+    setTransactionUserCategoryOverride('tx-3', 'cat-x')
+    expect(getTransactionUserData('tx-3')).toEqual({
+      transaction_id: 'tx-3',
+      user_notes: 'a note',
+      user_category_override: 'cat-x',
+    })
+
+    setTransactionUserNote('tx-3', null)
+    setTransactionUserCategoryOverride('tx-3', null)
+    expect(rawRow('tx-3')).toBeNull()
+  })
+
+  it('throws when the database is not ready', async () => {
+    const db = await import('@/db')
+    vi.mocked(db.getDb).mockReturnValue(null as never)
+    expect(() => setTransactionUserNote('tx-1', 'x')).toThrow(
+      'Database not ready'
+    )
+    expect(() => setTransactionUserCategoryOverride('tx-1', 'x')).toThrow(
+      'Database not ready'
+    )
+  })
+})

--- a/src/services/transactionUserData.ts
+++ b/src/services/transactionUserData.ts
@@ -60,17 +60,35 @@ export function getTransactionUserDataMap(
   return out
 }
 
-export function setTransactionUserNote(
+/** The two nullable user-owned columns on transaction_user_data. */
+type UserDataField = 'user_notes' | 'user_category_override'
+
+const SIBLING_FIELD: Record<UserDataField, UserDataField> = {
+  user_notes: 'user_category_override',
+  user_category_override: 'user_notes',
+}
+
+/**
+ * Set (or clear) one user-owned field on a transaction's row, keeping the row
+ * a pure overlay: a `null` value clears the field, and the row is deleted once
+ * both fields are empty so an untouched transaction has no row at all.
+ * `value` must already be normalised by the caller (trimmed, `''` → `null`).
+ * Field names come from the `UserDataField` union, never caller input, so the
+ * interpolation into the SQL is safe.
+ */
+function upsertUserDataField(
   transactionId: string,
-  userNotes: string | null
+  field: UserDataField,
+  value: string | null
 ): void {
   const db = getDb()
   if (!db) throw new Error('Database not ready')
   const existing = getTransactionUserData(transactionId)
-  if (userNotes === null || userNotes.trim() === '') {
-    if (existing?.user_category_override) {
+
+  if (value === null) {
+    if (existing?.[SIBLING_FIELD[field]]) {
       db.run(
-        `UPDATE transaction_user_data SET user_notes = NULL WHERE transaction_id = ?`,
+        `UPDATE transaction_user_data SET ${field} = NULL WHERE transaction_id = ?`,
         [transactionId]
       )
     } else if (existing) {
@@ -78,52 +96,43 @@ export function setTransactionUserNote(
         transactionId,
       ])
     }
+  } else if (existing) {
+    db.run(
+      `UPDATE transaction_user_data SET ${field} = ? WHERE transaction_id = ?`,
+      [value, transactionId]
+    )
   } else {
-    if (existing) {
-      db.run(
-        `UPDATE transaction_user_data SET user_notes = ? WHERE transaction_id = ?`,
-        [userNotes.trim(), transactionId]
-      )
-    } else {
-      db.run(
-        `INSERT INTO transaction_user_data (transaction_id, user_notes, user_category_override) VALUES (?, ?, NULL)`,
-        [transactionId, userNotes.trim()]
-      )
-    }
+    db.run(
+      `INSERT INTO transaction_user_data (transaction_id, user_notes, user_category_override) VALUES (?, ?, ?)`,
+      [
+        transactionId,
+        field === 'user_notes' ? value : null,
+        field === 'user_category_override' ? value : null,
+      ]
+    )
   }
   schedulePersist()
+}
+
+export function setTransactionUserNote(
+  transactionId: string,
+  userNotes: string | null
+): void {
+  const trimmed = userNotes?.trim() ?? ''
+  upsertUserDataField(
+    transactionId,
+    'user_notes',
+    trimmed === '' ? null : trimmed
+  )
 }
 
 export function setTransactionUserCategoryOverride(
   transactionId: string,
   categoryId: string | null
 ): void {
-  const db = getDb()
-  if (!db) throw new Error('Database not ready')
-  const existing = getTransactionUserData(transactionId)
-  if (categoryId === null || categoryId === '') {
-    if (existing?.user_notes) {
-      db.run(
-        `UPDATE transaction_user_data SET user_category_override = NULL WHERE transaction_id = ?`,
-        [transactionId]
-      )
-    } else if (existing) {
-      db.run(`DELETE FROM transaction_user_data WHERE transaction_id = ?`, [
-        transactionId,
-      ])
-    }
-  } else {
-    if (existing) {
-      db.run(
-        `UPDATE transaction_user_data SET user_category_override = ? WHERE transaction_id = ?`,
-        [categoryId, transactionId]
-      )
-    } else {
-      db.run(
-        `INSERT INTO transaction_user_data (transaction_id, user_notes, user_category_override) VALUES (?, NULL, ?)`,
-        [transactionId, categoryId]
-      )
-    }
-  }
-  schedulePersist()
+  upsertUserDataField(
+    transactionId,
+    'user_category_override',
+    categoryId === null || categoryId === '' ? null : categoryId
+  )
 }


### PR DESCRIPTION
Closes #6. Part of the #1 codebase-design deepening map (next frontier ticket after #2–#5).

## Problem
`setTransactionUserNote` and `setTransactionUserCategoryOverride` each hand-rolled the same four-way branch — **clear-field-keep-sibling / delete-row-when-both-empty / update / insert** — differing only by which column they touch. Two copies of a data-write branch that must stay in lockstep.

## Change
- New private `upsertUserDataField(transactionId, field: 'user_notes' | 'user_category_override', value: string | null)` implements the branch once.
- Both exports collapse to one-line callers that just normalise their argument (`setTransactionUserNote` trims and maps whitespace-only → `null`; `setTransactionUserCategoryOverride` maps `null`/`''` → `null`, no trim).
- `field` is a literal union, never caller input, so the identifier interpolation into the SQL is safe. Sibling-field lookup via a small `SIBLING_FIELD` map.

**No caller-visible change** — pure interior deepening. (Note: both setters currently have no callers in `src/`; `getTransactionUserDataMap` is the only used export. Left in place and now covered, per the map's "don't delete on a judgment call" rule.)

## Tests
New `src/services/transactionUserData.test.ts` — 14 cases against a live in-memory sql.js DB (same pattern as the `profileExport` `#36` block):
- insert / update / clear-one-keep-other / delete-when-both-empty, for **both** setters
- notes are trimmed and whitespace-only clears; category ids are **not** trimmed
- `null` and `''` category ids behave identically
- both fields independent on one row; row deleted once both cleared
- `Database not ready` throw

## Verification
`npm run validate` clean (0 errors); full unit suite **457 passing**.