### PR TITLE
Share validated-setting-load logic via loadValidatedSetting helper (#7)

### DIFF
--- a/src/lib/loadValidatedSetting.test.ts
+++ b/src/lib/loadValidatedSetting.test.ts
@@ -7,10 +7,7 @@ vi.mock('@/db', () => ({
 }))
 
 const mockGet = vi.mocked(getAppSetting)
-
-const isString = (v: unknown): v is string => typeof v === 'string'
-const isNumberArray = (v: unknown): v is number[] =>
-  Array.isArray(v) && v.every((n) => typeof n === 'number')
+const identity = (raw: string): string => raw
 
 describe('loadValidatedSetting', () => {
   beforeEach(() => {
@@ -19,52 +16,54 @@ describe('loadValidatedSetting', () => {
 
   it('returns the fallback when the key is missing', () => {
     mockGet.mockReturnValue(null)
-    expect(loadValidatedSetting('k', isString, 'fallback')).toBe('fallback')
+    expect(loadValidatedSetting('k', identity, 'fallback')).toBe('fallback')
   })
 
-  it('returns a valid plain-string value unchanged', () => {
+  it('returns whatever parse returns for a present value', () => {
     mockGet.mockReturnValue('dark')
-    expect(loadValidatedSetting('k', isString, 'fallback')).toBe('dark')
+    expect(loadValidatedSetting('k', identity, 'fallback')).toBe('dark')
   })
 
-  it('returns the fallback when the stored value fails validation', () => {
-    mockGet.mockReturnValue('42') // parses to a number, not a string
-    expect(loadValidatedSetting('k', isString, 'fallback')).toBe('fallback')
+  it('returns the fallback when parse rejects the value with null', () => {
+    mockGet.mockReturnValue('purple')
+    const parse = (raw: string) => (raw === 'dark' ? raw : null)
+    expect(loadValidatedSetting('k', parse, 'fallback')).toBe('fallback')
   })
 
-  it('JSON-parses the stored value before validating', () => {
-    mockGet.mockReturnValue('[1, 2, 3]')
-    expect(loadValidatedSetting('k', isNumberArray, [])).toEqual([1, 2, 3])
-  })
-
-  it('returns the fallback for a JSON value of the wrong shape', () => {
-    mockGet.mockReturnValue('[1, "two", 3]')
-    expect(loadValidatedSetting('k', isNumberArray, [])).toEqual([])
-  })
-
-  it('hands the raw string to validate when it is not valid JSON', () => {
-    mockGet.mockReturnValue('system') // JSON.parse throws -> raw string used
-    const seen: unknown[] = []
-    const spy = (v: unknown): v is string => {
-      seen.push(v)
-      return typeof v === 'string'
+  it('hands the raw string to parse verbatim (no JSON coercion)', () => {
+    mockGet.mockReturnValue('123')
+    const seen: string[] = []
+    const parse = (raw: string) => {
+      seen.push(raw)
+      return raw
     }
-    expect(loadValidatedSetting('k', spy, 'fallback')).toBe('system')
-    expect(seen).toEqual(['system'])
+    expect(loadValidatedSetting('k', parse, 'fallback')).toBe('123')
+    expect(seen).toEqual(['123'])
+  })
+
+  it('lets parse decode JSON and returns the decoded value', () => {
+    mockGet.mockReturnValue('[1, 2, 3]')
+    const parse = (raw: string) => JSON.parse(raw) as number[]
+    expect(loadValidatedSetting('k', parse, [])).toEqual([1, 2, 3])
+  })
+
+  it('returns the fallback when parse throws (e.g. JSON.parse on garbage)', () => {
+    mockGet.mockReturnValue('{not json')
+    const parse = (raw: string) => JSON.parse(raw) as unknown
+    expect(loadValidatedSetting('k', parse, 'fallback')).toBe('fallback')
   })
 
   it('returns the fallback when getAppSetting throws', () => {
     mockGet.mockImplementation(() => {
       throw new Error('db not ready')
     })
-    expect(loadValidatedSetting('k', isString, 'fallback')).toBe('fallback')
+    expect(loadValidatedSetting('k', identity, 'fallback')).toBe('fallback')
   })
 
-  it('returns the fallback when validate itself throws', () => {
-    mockGet.mockReturnValue('{"a":1}')
-    const throwing = (_v: unknown): _v is string => {
-      throw new Error('bad predicate')
-    }
-    expect(loadValidatedSetting('k', throwing, 'fallback')).toBe('fallback')
+  it('returns an empty-array result as-is rather than the fallback', () => {
+    mockGet.mockReturnValue('[]')
+    const sentinel = ['fallback']
+    const parse = (raw: string) => JSON.parse(raw) as string[]
+    expect(loadValidatedSetting('k', parse, sentinel)).toEqual([])
   })
 })

--- a/src/lib/loadValidatedSetting.test.ts
+++ b/src/lib/loadValidatedSetting.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { getAppSetting } from '@/db'
+import { loadValidatedSetting } from './loadValidatedSetting'
+
+vi.mock('@/db', () => ({
+  getAppSetting: vi.fn(),
+}))
+
+const mockGet = vi.mocked(getAppSetting)
+
+const isString = (v: unknown): v is string => typeof v === 'string'
+const isNumberArray = (v: unknown): v is number[] =>
+  Array.isArray(v) && v.every((n) => typeof n === 'number')
+
+describe('loadValidatedSetting', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('returns the fallback when the key is missing', () => {
+    mockGet.mockReturnValue(null)
+    expect(loadValidatedSetting('k', isString, 'fallback')).toBe('fallback')
+  })
+
+  it('returns a valid plain-string value unchanged', () => {
+    mockGet.mockReturnValue('dark')
+    expect(loadValidatedSetting('k', isString, 'fallback')).toBe('dark')
+  })
+
+  it('returns the fallback when the stored value fails validation', () => {
+    mockGet.mockReturnValue('42') // parses to a number, not a string
+    expect(loadValidatedSetting('k', isString, 'fallback')).toBe('fallback')
+  })
+
+  it('JSON-parses the stored value before validating', () => {
+    mockGet.mockReturnValue('[1, 2, 3]')
+    expect(loadValidatedSetting('k', isNumberArray, [])).toEqual([1, 2, 3])
+  })
+
+  it('returns the fallback for a JSON value of the wrong shape', () => {
+    mockGet.mockReturnValue('[1, "two", 3]')
+    expect(loadValidatedSetting('k', isNumberArray, [])).toEqual([])
+  })
+
+  it('hands the raw string to validate when it is not valid JSON', () => {
+    mockGet.mockReturnValue('system') // JSON.parse throws -> raw string used
+    const seen: unknown[] = []
+    const spy = (v: unknown): v is string => {
+      seen.push(v)
+      return typeof v === 'string'
+    }
+    expect(loadValidatedSetting('k', spy, 'fallback')).toBe('system')
+    expect(seen).toEqual(['system'])
+  })
+
+  it('returns the fallback when getAppSetting throws', () => {
+    mockGet.mockImplementation(() => {
+      throw new Error('db not ready')
+    })
+    expect(loadValidatedSetting('k', isString, 'fallback')).toBe('fallback')
+  })
+
+  it('returns the fallback when validate itself throws', () => {
+    mockGet.mockReturnValue('{"a":1}')
+    const throwing = (_v: unknown): _v is string => {
+      throw new Error('bad predicate')
+    }
+    expect(loadValidatedSetting('k', throwing, 'fallback')).toBe('fallback')
+  })
+})

--- a/src/lib/loadValidatedSetting.ts
+++ b/src/lib/loadValidatedSetting.ts
@@ -1,0 +1,37 @@
+import { getAppSetting } from '@/db'
+
+/**
+ * Read one `app_settings` value, validate it, and fall back on
+ * missing / invalid / thrown.
+ *
+ * The stored string is JSON-parsed when it can be (so JSON-encoded settings
+ * like `sidebar_pins` reach `validate` as the decoded value), and handed over
+ * as the raw string when it can't (so plain-string settings like `theme_mode`
+ * reach `validate` unchanged). `validate` is the single source of truth for
+ * what counts as usable; anything it rejects — along with a missing key or any
+ * thrown error — yields `fallback`.
+ *
+ * Consolidates the hand-rolled read → validate → fallback blocks that
+ * `themeStore` and `sidebarPinsStore` each carried separately.
+ */
+export function loadValidatedSetting<T>(
+  key: string,
+  validate: (value: unknown) => value is T,
+  fallback: T
+): T {
+  try {
+    const raw = getAppSetting(key)
+    if (raw == null) return fallback
+
+    let candidate: unknown = raw
+    try {
+      candidate = JSON.parse(raw)
+    } catch {
+      candidate = raw
+    }
+
+    return validate(candidate) ? candidate : fallback
+  } catch {
+    return fallback
+  }
+}

--- a/src/lib/loadValidatedSetting.ts
+++ b/src/lib/loadValidatedSetting.ts
@@ -1,36 +1,28 @@
 import { getAppSetting } from '@/db'
 
 /**
- * Read one `app_settings` value, validate it, and fall back on
- * missing / invalid / thrown.
+ * Read one `app_settings` value and hand it to `parse`, falling back on a
+ * missing key, a `null` result, or any thrown error.
  *
- * The stored string is JSON-parsed when it can be (so JSON-encoded settings
- * like `sidebar_pins` reach `validate` as the decoded value), and handed over
- * as the raw string when it can't (so plain-string settings like `theme_mode`
- * reach `validate` unchanged). `validate` is the single source of truth for
- * what counts as usable; anything it rejects — along with a missing key or any
- * thrown error — yields `fallback`.
+ * `parse` owns decoding and validation: it receives the raw stored string and
+ * returns the usable value, or `null` to reject it (JSON settings parse and
+ * shape-check inside it; plain-string settings just check the string). The
+ * helper only supplies the shared scaffold — read the key, treat absent as
+ * fallback, and never let a parse/storage error escape.
  *
  * Consolidates the hand-rolled read → validate → fallback blocks that
  * `themeStore` and `sidebarPinsStore` each carried separately.
  */
 export function loadValidatedSetting<T>(
   key: string,
-  validate: (value: unknown) => value is T,
+  parse: (raw: string) => T | null,
   fallback: T
 ): T {
   try {
     const raw = getAppSetting(key)
     if (raw == null) return fallback
-
-    let candidate: unknown = raw
-    try {
-      candidate = JSON.parse(raw)
-    } catch {
-      candidate = raw
-    }
-
-    return validate(candidate) ? candidate : fallback
+    const parsed = parse(raw)
+    return parsed == null ? fallback : parsed
   } catch {
     return fallback
   }

--- a/src/stores/sidebarPinsStore.test.ts
+++ b/src/stores/sidebarPinsStore.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { getAppSetting } from '@/db'
+import { sidebarPinsStore, type PinnedNavItem } from './sidebarPinsStore'
+
+vi.mock('@/db', () => ({
+  getAppSetting: vi.fn(),
+  setAppSetting: vi.fn(),
+}))
+
+const mockGet = vi.mocked(getAppSetting)
+
+const VALID: PinnedNavItem = {
+  path: '/analytics/reports',
+  label: 'Reports',
+  icon: 'mdi-file-chart',
+}
+
+describe('sidebarPinsStore.hydrateFromDb', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    sidebarPinsStore.setState({ pins: [], hydrated: false })
+  })
+
+  it('loads a well-formed stored list', () => {
+    mockGet.mockReturnValue(JSON.stringify([VALID]))
+    sidebarPinsStore.getState().hydrateFromDb()
+    expect(sidebarPinsStore.getState().pins).toEqual([VALID])
+    expect(sidebarPinsStore.getState().hydrated).toBe(true)
+  })
+
+  it('falls back to [] when nothing is stored', () => {
+    mockGet.mockReturnValue(null)
+    sidebarPinsStore.getState().hydrateFromDb()
+    expect(sidebarPinsStore.getState().pins).toEqual([])
+  })
+
+  it('drops only the malformed entries and keeps the valid ones', () => {
+    mockGet.mockReturnValue(
+      JSON.stringify([VALID, { path: '/x', label: 'X' }, { nope: true }])
+    )
+    sidebarPinsStore.getState().hydrateFromDb()
+    expect(sidebarPinsStore.getState().pins).toEqual([VALID])
+  })
+
+  it('falls back to [] on a non-array payload', () => {
+    mockGet.mockReturnValue('{"path":"/x"}')
+    sidebarPinsStore.getState().hydrateFromDb()
+    expect(sidebarPinsStore.getState().pins).toEqual([])
+  })
+
+  it('falls back to [] on invalid JSON', () => {
+    mockGet.mockReturnValue('[not json')
+    sidebarPinsStore.getState().hydrateFromDb()
+    expect(sidebarPinsStore.getState().pins).toEqual([])
+  })
+})

--- a/src/stores/sidebarPinsStore.ts
+++ b/src/stores/sidebarPinsStore.ts
@@ -44,12 +44,17 @@ function isPinnedNavItem(value: unknown): value is PinnedNavItem {
   )
 }
 
-function isPinnedNavItemArray(value: unknown): value is PinnedNavItem[] {
-  return Array.isArray(value) && value.every(isPinnedNavItem)
-}
-
 function loadPins(): PinnedNavItem[] {
-  return loadValidatedSetting(PINS_KEY, isPinnedNavItemArray, [])
+  return loadValidatedSetting(
+    PINS_KEY,
+    (raw) => {
+      const parsed = JSON.parse(raw) as unknown
+      // Keep the valid entries and drop only the malformed ones — a single
+      // bad pin (e.g. from a future required field) must not wipe the list.
+      return Array.isArray(parsed) ? parsed.filter(isPinnedNavItem) : null
+    },
+    []
+  )
 }
 
 function savePins(pins: PinnedNavItem[]): void {

--- a/src/stores/sidebarPinsStore.ts
+++ b/src/stores/sidebarPinsStore.ts
@@ -1,5 +1,6 @@
 import { createStore } from 'zustand/vanilla'
-import { getAppSetting, setAppSetting } from '@/db'
+import { setAppSetting } from '@/db'
+import { loadValidatedSetting } from '@/lib/loadValidatedSetting'
 
 export interface PinnedNavItem {
   path: string
@@ -33,23 +34,22 @@ interface SidebarPinsState {
 
 const PINS_KEY = 'sidebar_pins'
 
+function isPinnedNavItem(value: unknown): value is PinnedNavItem {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    typeof (value as Record<string, unknown>).path === 'string' &&
+    typeof (value as Record<string, unknown>).label === 'string' &&
+    typeof (value as Record<string, unknown>).icon === 'string'
+  )
+}
+
+function isPinnedNavItemArray(value: unknown): value is PinnedNavItem[] {
+  return Array.isArray(value) && value.every(isPinnedNavItem)
+}
+
 function loadPins(): PinnedNavItem[] {
-  try {
-    const raw = getAppSetting(PINS_KEY)
-    if (!raw) return []
-    const parsed = JSON.parse(raw) as unknown
-    if (!Array.isArray(parsed)) return []
-    return parsed.filter(
-      (p): p is PinnedNavItem =>
-        typeof p === 'object' &&
-        p !== null &&
-        typeof (p as Record<string, unknown>).path === 'string' &&
-        typeof (p as Record<string, unknown>).label === 'string' &&
-        typeof (p as Record<string, unknown>).icon === 'string'
-    )
-  } catch {
-    return []
-  }
+  return loadValidatedSetting(PINS_KEY, isPinnedNavItemArray, [])
 }
 
 function savePins(pins: PinnedNavItem[]): void {

--- a/src/stores/themeStore.ts
+++ b/src/stores/themeStore.ts
@@ -1,5 +1,6 @@
 import { createStore } from 'zustand/vanilla'
-import { getAppSetting, setAppSetting } from '@/db'
+import { setAppSetting } from '@/db'
+import { loadValidatedSetting } from '@/lib/loadValidatedSetting'
 
 export type ThemeMode = 'light' | 'dark' | 'system'
 
@@ -39,16 +40,12 @@ export const themeStore = createStore<ThemeStore>((set) => ({
   },
 
   hydrateFromDb() {
-    try {
-      const value = getAppSetting(THEME_SETTINGS_KEY)
-      if (value && isValidTheme(value)) {
-        set({ mode: value, hydrated: true })
-        localStorage.setItem(THEME_LOCALSTORAGE_KEY, value)
-        return
-      }
-      set({ mode: DEFAULT_THEME, hydrated: true })
-    } catch {
-      set({ mode: DEFAULT_THEME, hydrated: true })
-    }
+    const mode = loadValidatedSetting(
+      THEME_SETTINGS_KEY,
+      isValidTheme,
+      DEFAULT_THEME
+    )
+    set({ mode, hydrated: true })
+    localStorage.setItem(THEME_LOCALSTORAGE_KEY, mode)
   },
 }))

--- a/src/stores/themeStore.ts
+++ b/src/stores/themeStore.ts
@@ -42,10 +42,17 @@ export const themeStore = createStore<ThemeStore>((set) => ({
   hydrateFromDb() {
     const mode = loadValidatedSetting(
       THEME_SETTINGS_KEY,
-      isValidTheme,
+      (raw) => (isValidTheme(raw) ? raw : null),
       DEFAULT_THEME
     )
     set({ mode, hydrated: true })
-    localStorage.setItem(THEME_LOCALSTORAGE_KEY, mode)
+    try {
+      localStorage.setItem(THEME_LOCALSTORAGE_KEY, mode)
+    } catch {
+      // Storage unavailable (private mode / quota / disabled). App.tsx's theme
+      // effect re-mirrors this on its next run and index.html's pre-paint
+      // script falls back to its own default — a failed write must not wedge
+      // the boot sequence, which calls hydrateFromDb() outside any try/catch.
+    }
   },
 }))


### PR DESCRIPTION
Closes #7. Part of the #1 codebase-design deepening map (frontier ticket after #6).

## Problem
`themeStore.hydrateFromDb` and `sidebarPinsStore.loadPins` each hand-rolled the same shape — *read a setting via `getAppSetting`, validate/parse it, fall back to a default on missing / invalid / thrown* — with independently written try/catch and validation.

## Change
**New `src/lib/loadValidatedSetting.ts`:**
```ts
loadValidatedSetting<T>(key: string, parse: (raw: string) => T | null, fallback: T): T
```
Reads the setting; hands the raw stored string to `parse`, which fully owns decoding + validation and returns the usable value or `null` to reject it. The helper only supplies the shared scaffold: read the key, treat an absent key as `fallback`, and never let a parse/storage error escape.

- **themeStore** — `hydrateFromDb` uses `parse = raw => isValidTheme(raw) ? raw : null`. The `localStorage` mirror write is wrapped in its own `try/catch` (see note 1).
- **sidebarPinsStore** — `isPinnedNavItem` guard extracted; `loadPins`'s `parse` decodes JSON and **filters to the valid entries** (a single malformed pin doesn't wipe the list); non-array → `null` → `[]`.

## Review round (findings from `/code-review 43`, all fixed in `6c8eb76`)
1. **Boot-wedge regression** — the first cut ran `localStorage.setItem` in `hydrateFromDb` outside any `try/catch`; `App.tsx`'s `boot()` calls `hydrateFromDb()` unguarded, so a storage exception (iOS private mode / quota / disabled) would leave the app stuck on the loading screen. The old code wrapped that write — restored a targeted guard.
2. **All-or-nothing pins** — the first cut validated the whole array, so one bad entry discarded every pin. Restored the filter-to-valid-subset behaviour.
3. **JSON.parse heuristic** — the first cut's "parse if it can, else raw string" in the helper could silently coerce a plain-string setting whose value was valid JSON. Removed; `parse` is now fully caller-controlled.

## Behaviour note (benign, unchanged from first cut)
`themeStore.hydrateFromDb` now always mirrors the resolved mode into `localStorage` (not only on the valid-DB-value path). Its sole caller (`App.tsx:101`) is immediately followed by the theme effect (`App.tsx:76`) that writes the same value once `hydrated` flips; `index.html`'s pre-paint script only reads on the next load. End state unchanged.

## Tests
- `src/lib/loadValidatedSetting.test.ts` — 8 cases: missing key, present value, `parse` returns `null` → fallback, raw string passed verbatim, `parse` decodes JSON, `parse` throws → fallback, `getAppSetting` throws → fallback, empty-array result returned as-is.
- `src/stores/sidebarPinsStore.test.ts` (new) — 5 cases: well-formed list, nothing stored, **drop-one-keep-rest**, non-array payload, invalid JSON.

## Verification
`npm run validate` clean (0 errors); full unit suite **470 passing**.
