### PR TITLE
Consolidate the three Base64<->bytes implementations (#8)

### DIFF
--- a/src/lib/base64.test.ts
+++ b/src/lib/base64.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect } from 'vitest'
+import { bufferToBase64, base64ToBuffer } from './base64'
+
+// ── the three pre-consolidation implementations, reproduced verbatim ──────
+
+// crypto.ts
+function cryptoEncode(buffer: ArrayBuffer): string {
+  const bytes = new Uint8Array(buffer)
+  let binary = ''
+  for (let i = 0; i < bytes.length; i++) binary += String.fromCharCode(bytes[i])
+  return btoa(binary)
+}
+function cryptoDecode(base64: string): ArrayBuffer {
+  const binary = atob(base64)
+  const bytes = new Uint8Array(binary.length)
+  for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i)
+  return bytes.buffer
+}
+
+// biometricSession.ts (identical shape to the webauthn.ts inline version)
+function bioEncode(buf: ArrayBuffer): string {
+  return btoa(String.fromCharCode(...new Uint8Array(buf)))
+}
+function bioDecode(s: string): Uint8Array {
+  return Uint8Array.from(atob(s), (c) => c.charCodeAt(0))
+}
+
+function randomBytes(n: number): Uint8Array {
+  const b = new Uint8Array(n)
+  for (let i = 0; i < n; i++) b[i] = (i * 37 + 11) & 0xff
+  return b
+}
+
+describe('base64', () => {
+  it('round-trips key-material-shaped buffers (32 / 16 / 12 bytes)', () => {
+    for (const n of [32, 16, 12]) {
+      const original = randomBytes(n)
+      const decoded = base64ToBuffer(bufferToBase64(original))
+      expect(Array.from(decoded)).toEqual(Array.from(original))
+    }
+  })
+
+  it('round-trips every byte value 0x00–0xff', () => {
+    const all = new Uint8Array(256)
+    for (let i = 0; i < 256; i++) all[i] = i
+    expect(Array.from(base64ToBuffer(bufferToBase64(all)))).toEqual(
+      Array.from(all)
+    )
+  })
+
+  it('encodes byte-identically to the pre-change crypto.ts implementation', () => {
+    const key = randomBytes(32)
+    expect(bufferToBase64(key)).toBe(cryptoEncode(key.buffer))
+  })
+
+  it('encodes byte-identically to the pre-change biometric/webauthn implementation', () => {
+    const raw = randomBytes(48)
+    expect(bufferToBase64(raw)).toBe(bioEncode(raw.buffer))
+  })
+
+  it('decodes to the same bytes as both pre-change implementations', () => {
+    const b64 = bufferToBase64(randomBytes(32))
+    expect(Array.from(base64ToBuffer(b64))).toEqual(
+      Array.from(new Uint8Array(cryptoDecode(b64)))
+    )
+    expect(Array.from(base64ToBuffer(b64))).toEqual(Array.from(bioDecode(b64)))
+  })
+
+  it('accepts an ArrayBuffer or a Uint8Array view and yields the same string', () => {
+    const bytes = randomBytes(20)
+    expect(bufferToBase64(bytes)).toBe(bufferToBase64(bytes.buffer))
+  })
+
+  it('returns a Uint8Array from base64ToBuffer', () => {
+    expect(base64ToBuffer(bufferToBase64(randomBytes(8)))).toBeInstanceOf(
+      Uint8Array
+    )
+  })
+
+  it('handles the empty buffer', () => {
+    expect(bufferToBase64(new Uint8Array(0))).toBe('')
+    expect(base64ToBuffer('').length).toBe(0)
+  })
+})

--- a/src/lib/base64.ts
+++ b/src/lib/base64.ts
@@ -1,0 +1,30 @@
+/**
+ * Base64 ⇄ bytes conversion shared by the crypto and biometric-auth layers.
+ *
+ * This is the "binary string" scheme: one character per byte via
+ * `String.fromCharCode` / `charCodeAt`, wrapped with `btoa` / `atob`. Every
+ * caller — API-token encryption (`crypto.ts`), WebAuthn credential ids
+ * (`webauthn.ts`), and the biometric session blob (`biometricSession.ts`) —
+ * has always used exactly this encoding. Consolidating three copies; the
+ * format itself must not change.
+ */
+
+/** Encode bytes as a base64 string. Accepts an ArrayBuffer or a typed-array view. */
+export function bufferToBase64(input: ArrayBuffer | Uint8Array): string {
+  const bytes = input instanceof Uint8Array ? input : new Uint8Array(input)
+  let binary = ''
+  for (let i = 0; i < bytes.length; i++) {
+    binary += String.fromCharCode(bytes[i])
+  }
+  return btoa(binary)
+}
+
+/** Decode a base64 string to bytes. */
+export function base64ToBuffer(base64: string): Uint8Array {
+  const binary = atob(base64)
+  const bytes = new Uint8Array(binary.length)
+  for (let i = 0; i < binary.length; i++) {
+    bytes[i] = binary.charCodeAt(i)
+  }
+  return bytes
+}

--- a/src/lib/biometricSession.ts
+++ b/src/lib/biometricSession.ts
@@ -1,13 +1,7 @@
+import { bufferToBase64, base64ToBuffer } from './base64'
+
 const KEY_LS = 'vantura_bio_key'
 const TOKEN_SS = 'vantura_bio_token'
-
-function b64(buf: ArrayBuffer): string {
-  return btoa(String.fromCharCode(...new Uint8Array(buf)))
-}
-
-function fromb64(s: string): Uint8Array {
-  return Uint8Array.from(atob(s), (c) => c.charCodeAt(0))
-}
 
 export async function storeBiometricSession(apiToken: string): Promise<void> {
   const key = await crypto.subtle.generateKey(
@@ -22,10 +16,10 @@ export async function storeBiometricSession(apiToken: string): Promise<void> {
     key,
     new TextEncoder().encode(apiToken)
   )
-  localStorage.setItem(KEY_LS, b64(rawKey))
+  localStorage.setItem(KEY_LS, bufferToBase64(rawKey))
   sessionStorage.setItem(
     TOKEN_SS,
-    JSON.stringify({ iv: b64(iv.buffer), ct: b64(ciphertext) })
+    JSON.stringify({ iv: bufferToBase64(iv), ct: bufferToBase64(ciphertext) })
   )
 }
 
@@ -40,15 +34,15 @@ export async function retrieveBiometricSession(): Promise<string | null> {
     }
     const key = await crypto.subtle.importKey(
       'raw',
-      fromb64(keyB64),
+      base64ToBuffer(keyB64),
       { name: 'AES-GCM' },
       false,
       ['decrypt']
     )
     const decrypted = await crypto.subtle.decrypt(
-      { name: 'AES-GCM', iv: fromb64(ivB64) },
+      { name: 'AES-GCM', iv: base64ToBuffer(ivB64) },
       key,
-      fromb64(ctB64)
+      base64ToBuffer(ctB64)
     )
     return new TextDecoder().decode(decrypted)
   } catch {

--- a/src/lib/crypto.ts
+++ b/src/lib/crypto.ts
@@ -4,29 +4,13 @@
  * Salt and IV are stored with ciphertext; passphrase and raw key are never stored.
  */
 
+import { bufferToBase64, base64ToBuffer } from './base64'
+
 const PBKDF2_ITERATIONS = 100_000
 const KEY_LENGTH_BITS = 256
 const SALT_LENGTH_BYTES = 16
 const IV_LENGTH_BYTES = 12
 const AES_GCM_TAG_LENGTH_BITS = 128
-
-function bufferToBase64(buffer: ArrayBuffer): string {
-  const bytes = new Uint8Array(buffer)
-  let binary = ''
-  for (let i = 0; i < bytes.length; i++) {
-    binary += String.fromCharCode(bytes[i])
-  }
-  return btoa(binary)
-}
-
-function base64ToBuffer(base64: string): ArrayBuffer {
-  const binary = atob(base64)
-  const bytes = new Uint8Array(binary.length)
-  for (let i = 0; i < binary.length; i++) {
-    bytes[i] = binary.charCodeAt(i)
-  }
-  return bytes.buffer
-}
 
 /**
  * Generate a random salt for key derivation. Store in app_settings.encryption_salt (e.g. base64).

--- a/src/lib/webauthn.ts
+++ b/src/lib/webauthn.ts
@@ -1,3 +1,5 @@
+import { bufferToBase64, base64ToBuffer } from './base64'
+
 export async function isBiometricAvailable(): Promise<boolean> {
   if (!window.PublicKeyCredential) return false
   try {
@@ -34,7 +36,7 @@ export async function registerBiometric(): Promise<string> {
     throw new Error('Biometric registration failed')
   }
 
-  return btoa(String.fromCharCode(...new Uint8Array(credential.rawId)))
+  return bufferToBase64(credential.rawId)
 }
 
 export async function verifyBiometric(
@@ -42,7 +44,7 @@ export async function verifyBiometric(
 ): Promise<boolean> {
   const challenge = crypto.getRandomValues(new Uint8Array(32))
   const rpId = window.location.hostname
-  const credId = Uint8Array.from(atob(credentialIdB64), (c) => c.charCodeAt(0))
+  const credId = base64ToBuffer(credentialIdB64)
 
   const assertion = await navigator.credentials.get({
     publicKey: {


### PR DESCRIPTION
Closes #8. Part of the #1 codebase-design deepening map (frontier ticket after #7).

## Problem
Base64 ⇄ bytes conversion existed **three ways**:
- `crypto.ts` — private `bufferToBase64` / `base64ToBuffer` (loop + `btoa`/`atob`), not exported.
- `webauthn.ts` — inline `btoa(String.fromCharCode(...))` / `Uint8Array.from(atob(...))` in `registerBiometric` / `verifyBiometric`.
- `biometricSession.ts` — local `b64` / `fromb64`.

## Change
New **`src/lib/base64.ts`** exports `bufferToBase64` / `base64ToBuffer` using the exact "binary string" scheme every caller already used (one char per byte, `btoa`/`atob`) — kept in the **loop form** so there's no spread-arg call-stack limit. `crypto.ts`, `webauthn.ts` and `biometricSession.ts` import it; their local copies are deleted.

Mechanical-only differences:
- `bufferToBase64` accepts `ArrayBuffer | Uint8Array` — `crypto.generateSalt` and `biometricSession`'s `iv` hand it a view.
- `base64ToBuffer` returns `Uint8Array` (matches two of the three originals; every consumer takes `BufferSource`). `decryptToken` keeps its `new Uint8Array(base64ToBuffer(...))` wrap — now a harmless copy instead of a view, same bytes, so `crypto.ts`'s diff stays pure deletion.

**Encoding/wire format unchanged** — so `SECURITY.md` / `docs/features/security-auth/` need no update.

## Tests
New `src/lib/base64.test.ts` (8): round-trips 32 / 16 / 12-byte (key / salt / IV shaped) and full-range `0x00–0xff` buffers; asserts **byte-identical output to each of the three reproduced pre-change implementations** (encode + decode); ArrayBuffer vs Uint8Array input parity; empty buffer. `crypto.test.ts`'s `encryptToken`/`decryptToken` round-trip continues to exercise the real path through the shared helper.

## Verification
`npm run validate` clean (0 errors); full unit suite **478 passing**.