### PR TITLE
Drop the silently-ignored options param from toast success/error (#9)

### DIFF
--- a/src/stores/toastStore.test.ts
+++ b/src/stores/toastStore.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { toastStore, toast } from './toastStore'
+
+describe('toastStore', () => {
+  beforeEach(() => {
+    toastStore.getState().hide()
+  })
+
+  it('success() shows an auto-dismissing success toast', () => {
+    toast.success('Saved.')
+    expect(toastStore.getState()).toMatchObject({
+      show: true,
+      message: 'Saved.',
+      variant: 'success',
+      persistent: false,
+    })
+  })
+
+  it('error() shows an auto-dismissing error toast', () => {
+    toast.error('Nope.')
+    expect(toastStore.getState()).toMatchObject({
+      show: true,
+      message: 'Nope.',
+      variant: 'error',
+      persistent: false,
+    })
+  })
+
+  it('info() defaults to auto-dismiss', () => {
+    toast.info('Working…')
+    expect(toastStore.getState()).toMatchObject({
+      variant: 'info',
+      persistent: false,
+    })
+  })
+
+  it('info() honours { persistent: true }', () => {
+    toast.info('Syncing…', { persistent: true })
+    expect(toastStore.getState().persistent).toBe(true)
+  })
+
+  it('success() after a persistent info() clears the persistent flag', () => {
+    toast.info('Syncing…', { persistent: true })
+    toast.success('Done.')
+    expect(toastStore.getState().persistent).toBe(false)
+  })
+
+  it('hide() resets show and persistent', () => {
+    toast.info('Syncing…', { persistent: true })
+    toast.hide()
+    expect(toastStore.getState()).toMatchObject({
+      show: false,
+      persistent: false,
+    })
+  })
+
+  it('success() and error() take no options argument', () => {
+    // @ts-expect-error success() has no options parameter
+    toast.success('x', { persistent: true })
+    // @ts-expect-error error() has no options parameter
+    toast.error('x', { persistent: true })
+  })
+})

--- a/src/stores/toastStore.ts
+++ b/src/stores/toastStore.ts
@@ -2,6 +2,9 @@
  * Global toast notifications. Use toast.success(), toast.error(), toast.info()
  * from anywhere. ToastProvider renders the toast and auto-dismisses unless
  * info(..., { persistent: true }) is used (e.g. long-running sync progress).
+ *
+ * `persistent` is an info()-only option — success and error toasts always
+ * auto-dismiss, so they take no options rather than a silently-ignored one.
  */
 
 import { createStore } from 'zustand/vanilla'
@@ -20,8 +23,8 @@ type ToastState = {
 }
 
 type ToastActions = {
-  success: (message: string, options?: ToastShowOptions) => void
-  error: (message: string, options?: ToastShowOptions) => void
+  success: (message: string) => void
+  error: (message: string) => void
   info: (message: string, options?: ToastShowOptions) => void
   hide: () => void
 }
@@ -34,11 +37,11 @@ export const toastStore = createStore<ToastStore>((set) => ({
   variant: 'success',
   persistent: false,
 
-  success(message: string, _options?: ToastShowOptions) {
+  success(message: string) {
     set({ show: true, message, variant: 'success', persistent: false })
   },
 
-  error(message: string, _options?: ToastShowOptions) {
+  error(message: string) {
     set({ show: true, message, variant: 'error', persistent: false })
   },
 
@@ -58,10 +61,8 @@ export const toastStore = createStore<ToastStore>((set) => ({
 
 /** Convenience API: toast.success('Done.') */
 export const toast = {
-  success: (message: string, options?: ToastShowOptions) =>
-    toastStore.getState().success(message, options),
-  error: (message: string, options?: ToastShowOptions) =>
-    toastStore.getState().error(message, options),
+  success: (message: string) => toastStore.getState().success(message),
+  error: (message: string) => toastStore.getState().error(message),
   info: (message: string, options?: ToastShowOptions) =>
     toastStore.getState().info(message, options),
   hide: () => toastStore.getState().hide(),


### PR DESCRIPTION
Closes #9. Part of the #1 codebase-design deepening map (frontier ticket after #8).

## Problem
`toastStore`'s `success()` and `error()` accepted `_options?: ToastShowOptions` but never read it — only `info()` honours `persistent`. `toast.success(msg, { persistent: true })` was a silent no-op: a leaky, inconsistent interface.

## Change
Removed the parameter from the action types, the store methods, and the `toast.*` convenience wrappers. `ToastShowOptions` stays — `info()` still uses it.

**No call site passed a second argument** to `success` / `error`. All ~55 `toast.success` / `toast.error` calls across the app are single-argument, so nothing else changes and there's no silent-no-op bug to fix at a call site.

## Tests
New `src/stores/toastStore.test.ts` (7): success/error set the right variant and always `persistent: false`; `info()`'s auto-dismiss default and `{ persistent: true }` opt-in; `success()` after a persistent `info()` clears the flag; `hide()` reset; a `@ts-expect-error` guard that `success` / `error` reject an options argument.

## Verification
`npm run validate` clean (0 errors); full unit suite **485 passing**.