### PR TITLE
Extract pure classifySwipe() from useEdgeSwipe.ts (#10)

### DIFF
--- a/src/hooks/useEdgeSwipe.ts
+++ b/src/hooks/useEdgeSwipe.ts
@@ -1,19 +1,24 @@
 import { useEffect } from 'react'
 import { uiStore } from '@/stores/uiStore'
-
-const EDGE_ZONE_PX = 40 // touches starting within this many px of the left edge trigger open
-const OPEN_THRESHOLD_PX = 60 // minimum rightward travel to open
-const CLOSE_THRESHOLD_PX = 60 // minimum leftward travel to close
-const MAX_VERTICAL_DRIFT_PX = 80 // maximum vertical travel before gesture is treated as a scroll
+import {
+  EDGE_SWIPE,
+  classifySwipe,
+  shouldLockScrollDuringOpenSwipe,
+  type EdgeSwipeMode,
+} from '@/lib/edgeSwipe'
 
 /**
  * Attaches touch-swipe listeners to the document so that:
- *   - a rightward swipe starting within EDGE_ZONE_PX of the left edge opens the mobile sidebar
+ *   - a rightward swipe starting within EDGE_SWIPE.edgeZonePx of the left edge
+ *     opens the mobile sidebar
  *   - a leftward swipe anywhere closes it
  *
  * Should only be enabled when the mobile overlay sidebar is in use (isMobile === true).
  * Calls e.preventDefault() on touchmove for detected open-swipes so that the browser
  * back-navigation gesture and any scroll are suppressed while the swipe is in progress.
+ *
+ * All gesture arithmetic lives in `@/lib/edgeSwipe`; this hook only captures the
+ * touch start point / mode and dispatches the result to `uiStore`.
  */
 export function useEdgeSwipe(enabled: boolean): void {
   useEffect(() => {
@@ -21,13 +26,13 @@ export function useEdgeSwipe(enabled: boolean): void {
 
     let startX = 0
     let startY = 0
-    let mode: 'open' | 'close' | null = null
+    let mode: EdgeSwipeMode = null
 
     function handleTouchStart(e: TouchEvent) {
       startX = e.touches[0].clientX
       startY = e.touches[0].clientY
       const isOpen = uiStore.getState().sidebarMobileOpen
-      if (!isOpen && startX <= EDGE_ZONE_PX) {
+      if (!isOpen && startX <= EDGE_SWIPE.edgeZonePx) {
         mode = 'open'
       } else if (isOpen) {
         mode = 'close'
@@ -40,8 +45,7 @@ export function useEdgeSwipe(enabled: boolean): void {
       if (mode !== 'open') return
       const dx = e.touches[0].clientX - startX
       const dy = Math.abs(e.touches[0].clientY - startY)
-      // Suppress back-navigation once we're confident this is a horizontal open swipe
-      if (dx > 8 && dy < dx) {
+      if (shouldLockScrollDuringOpenSwipe({ dx, dy })) {
         e.preventDefault()
       }
     }
@@ -50,15 +54,10 @@ export function useEdgeSwipe(enabled: boolean): void {
       if (!mode) return
       const dx = e.changedTouches[0].clientX - startX
       const dy = Math.abs(e.changedTouches[0].clientY - startY)
-      const isHorizontal = dy < MAX_VERTICAL_DRIFT_PX && Math.abs(dx) > dy
-
-      if (mode === 'open' && dx >= OPEN_THRESHOLD_PX && isHorizontal) {
+      const result = classifySwipe({ mode, dx, dy })
+      if (result === 'open-triggered') {
         uiStore.getState().setSidebarMobileOpen(true)
-      } else if (
-        mode === 'close' &&
-        dx <= -CLOSE_THRESHOLD_PX &&
-        isHorizontal
-      ) {
+      } else if (result === 'close-triggered') {
         uiStore.getState().setSidebarMobileOpen(false)
       }
       mode = null

--- a/src/lib/edgeSwipe.test.ts
+++ b/src/lib/edgeSwipe.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect } from 'vitest'
+import {
+  EDGE_SWIPE,
+  classifySwipe,
+  shouldLockScrollDuringOpenSwipe,
+} from './edgeSwipe'
+
+const OPEN = EDGE_SWIPE.openThresholdPx // 60
+const CLOSE = EDGE_SWIPE.closeThresholdPx // 60
+const DRIFT = EDGE_SWIPE.maxVerticalDriftPx // 80
+
+describe('classifySwipe', () => {
+  it('ignores when no mode was captured at touchstart', () => {
+    expect(classifySwipe({ mode: null, dx: 999, dy: 0 })).toBe('ignore')
+  })
+
+  describe('open (rightward from the left edge)', () => {
+    it('triggers exactly at the open threshold', () => {
+      expect(classifySwipe({ mode: 'open', dx: OPEN, dy: 0 })).toBe(
+        'open-triggered'
+      )
+    })
+
+    it('does not trigger one px short of the threshold', () => {
+      expect(classifySwipe({ mode: 'open', dx: OPEN - 1, dy: 0 })).toBe(
+        'ignore'
+      )
+    })
+
+    it('triggers past the threshold', () => {
+      expect(classifySwipe({ mode: 'open', dx: OPEN + 40, dy: 10 })).toBe(
+        'open-triggered'
+      )
+    })
+
+    it('ignores a leftward drag while in open mode', () => {
+      expect(classifySwipe({ mode: 'open', dx: -OPEN - 10, dy: 0 })).toBe(
+        'ignore'
+      )
+    })
+  })
+
+  describe('close (leftward)', () => {
+    it('triggers exactly at the close threshold', () => {
+      expect(classifySwipe({ mode: 'close', dx: -CLOSE, dy: 0 })).toBe(
+        'close-triggered'
+      )
+    })
+
+    it('does not trigger one px short of the threshold', () => {
+      expect(classifySwipe({ mode: 'close', dx: -CLOSE + 1, dy: 0 })).toBe(
+        'ignore'
+      )
+    })
+
+    it('triggers past the threshold', () => {
+      expect(classifySwipe({ mode: 'close', dx: -CLOSE - 40, dy: 10 })).toBe(
+        'close-triggered'
+      )
+    })
+
+    it('ignores a rightward drag while in close mode', () => {
+      expect(classifySwipe({ mode: 'close', dx: CLOSE + 10, dy: 0 })).toBe(
+        'ignore'
+      )
+    })
+  })
+
+  describe('vertical drift / scroll rejection', () => {
+    it('accepts vertical travel just under the drift limit', () => {
+      expect(
+        classifySwipe({ mode: 'open', dx: OPEN + 30, dy: DRIFT - 1 })
+      ).toBe('open-triggered')
+    })
+
+    it('rejects vertical travel at the drift limit', () => {
+      expect(classifySwipe({ mode: 'open', dx: OPEN + 30, dy: DRIFT })).toBe(
+        'ignore'
+      )
+    })
+
+    it('rejects a diagonal where vertical travel meets or exceeds horizontal', () => {
+      expect(classifySwipe({ mode: 'open', dx: OPEN, dy: OPEN })).toBe('ignore')
+      expect(classifySwipe({ mode: 'open', dx: OPEN + 5, dy: OPEN + 5 })).toBe(
+        'ignore'
+      )
+    })
+  })
+})
+
+describe('shouldLockScrollDuringOpenSwipe', () => {
+  it('is false until horizontal travel passes the lock minimum', () => {
+    expect(
+      shouldLockScrollDuringOpenSwipe({
+        dx: EDGE_SWIPE.scrollLockMinDxPx,
+        dy: 0,
+      })
+    ).toBe(false)
+    expect(
+      shouldLockScrollDuringOpenSwipe({
+        dx: EDGE_SWIPE.scrollLockMinDxPx + 1,
+        dy: 0,
+      })
+    ).toBe(true)
+  })
+
+  it('is false once vertical travel catches up to horizontal', () => {
+    expect(shouldLockScrollDuringOpenSwipe({ dx: 20, dy: 19 })).toBe(true)
+    expect(shouldLockScrollDuringOpenSwipe({ dx: 20, dy: 20 })).toBe(false)
+    expect(shouldLockScrollDuringOpenSwipe({ dx: 20, dy: 30 })).toBe(false)
+  })
+
+  it('is false for a leftward drag', () => {
+    expect(shouldLockScrollDuringOpenSwipe({ dx: -20, dy: 0 })).toBe(false)
+  })
+})

--- a/src/lib/edgeSwipe.ts
+++ b/src/lib/edgeSwipe.ts
@@ -1,0 +1,62 @@
+/**
+ * Pure gesture math for the mobile edge-swipe sidebar (`useEdgeSwipe`).
+ * The hook is a thin DOM adapter: it captures the touch start point and the
+ * mode, then defers every arithmetic decision to the functions here.
+ */
+
+/** Which sidebar action the gesture that started is a candidate for. */
+export type EdgeSwipeMode = 'open' | 'close' | null
+
+export const EDGE_SWIPE = {
+  /** Touches starting within this many px of the left edge can trigger open. */
+  edgeZonePx: 40,
+  /** Minimum rightward travel to open. */
+  openThresholdPx: 60,
+  /** Minimum leftward travel to close. */
+  closeThresholdPx: 60,
+  /** Maximum vertical travel before the gesture is treated as a scroll. */
+  maxVerticalDriftPx: 80,
+  /** Minimum rightward travel before an in-progress open swipe locks scroll. */
+  scrollLockMinDxPx: 8,
+} as const
+
+/**
+ * Decide what a completed touch gesture does to the mobile sidebar.
+ * `dx` is signed end-minus-start horizontal travel; `dy` is the absolute
+ * vertical travel. `mode` is what was captured at touchstart.
+ */
+export function classifySwipe({
+  mode,
+  dx,
+  dy,
+}: {
+  mode: EdgeSwipeMode
+  dx: number
+  dy: number
+}): 'open-triggered' | 'close-triggered' | 'ignore' {
+  if (!mode) return 'ignore'
+
+  const isHorizontal = dy < EDGE_SWIPE.maxVerticalDriftPx && Math.abs(dx) > dy
+  if (!isHorizontal) return 'ignore'
+
+  if (mode === 'open' && dx >= EDGE_SWIPE.openThresholdPx)
+    return 'open-triggered'
+  if (mode === 'close' && dx <= -EDGE_SWIPE.closeThresholdPx)
+    return 'close-triggered'
+  return 'ignore'
+}
+
+/**
+ * During an in-progress open swipe, whether we're confident enough it's a
+ * horizontal drag (rather than a vertical scroll) to call `preventDefault`
+ * and suppress the browser back-navigation gesture. `dy` is absolute.
+ */
+export function shouldLockScrollDuringOpenSwipe({
+  dx,
+  dy,
+}: {
+  dx: number
+  dy: number
+}): boolean {
+  return dx > EDGE_SWIPE.scrollLockMinDxPx && dy < dx
+}


### PR DESCRIPTION
Closes #10. Part of the #1 codebase-design deepening map — the last of the sharp direct-fix tickets (#11, #12 are investigate-first).

## Problem
`useEdgeSwipe`'s gesture decision — direction, thresholds, horizontal-vs-scroll, and the touchmove scroll-lock heuristic — was inlined in the DOM handlers, exercisable only by simulating touch events. No direct test surface for the arithmetic.

## Change
**New `src/lib/edgeSwipe.ts`:**
- `classifySwipe({ mode, dx, dy }) → 'open-triggered' | 'close-triggered' | 'ignore'` — the touchend commit decision.
- `shouldLockScrollDuringOpenSwipe({ dx, dy }) → boolean` — the touchmove `preventDefault` gate (was `dx > 8 && dy < dx`).
- `EDGE_SWIPE` constants object (was four module-level `*_PX` consts).

`useEdgeSwipe` is now a thin adapter: capture the touch start point + mode, defer to the pure functions, dispatch to `uiStore`. **Signature and behaviour unchanged** — the threshold arithmetic is byte-for-byte the same, just relocated. One caller (`Layout.tsx`), untouched.

## Tests
`src/lib/edgeSwipe.test.ts` (15): open + close directions; each threshold boundary (exact / one px short / well past); the vertical-drift limit (`dy < 80`, so 79 accepts, 80 rejects); diagonal rejection (`|dx| > dy`); wrong-direction rejection; `mode: null`; and `shouldLockScrollDuringOpenSwipe`'s lock minimum + vertical catch-up boundaries.

## Verification
`npm run validate` clean (0 errors); full unit suite **500 passing**.