### PR TITLE
Consolidate date-string arithmetic into src/lib/dateStr.ts (#11)

### DIFF
--- a/src/components/dashboard/TrackersSection.tsx
+++ b/src/components/dashboard/TrackersSection.tsx
@@ -33,6 +33,11 @@ import {
   type BudgetDisplayPeriod,
 } from '@/lib/monthlyEquivalent'
 import { formatMoney, formatShortDate } from '@/lib/format'
+import {
+  addDaysToDateStr,
+  calendarPeriodBounds,
+  daysBetweenDateStr,
+} from '@/lib/dateStr'
 import { toast } from '@/stores/toastStore'
 import { syncStore } from '@/stores/syncStore'
 import { HelpPopover } from '@/components/HelpPopover'
@@ -55,9 +60,7 @@ const FREQUENCY_ORDER: TrackerResetFrequency[] = [
 // period_end is exclusive (the reset date / first day of next period), so subtract
 // one day to get the last inclusive day for display purposes.
 function displayPeriodEnd(isoDate: string): string {
-  const d = new Date(isoDate + 'T12:00:00Z')
-  d.setUTCDate(d.getUTCDate() - 1)
-  return d.toISOString().slice(0, 10)
+  return addDaysToDateStr(isoDate, -1)
 }
 
 function getTrackerProgressStyle(progress: number): {
@@ -88,46 +91,22 @@ function getCalendarPeriodBounds(period: BudgetDisplayPeriod): {
   to: string
   label: string
 } {
-  const today = new Date()
-  if (period === 'WEEKLY') {
-    const day = today.getUTCDay()
-    const daysFromMonday = (day + 6) % 7
-    const monday = new Date(today)
-    monday.setUTCDate(today.getUTCDate() - daysFromMonday)
-    const nextMonday = new Date(monday)
-    nextMonday.setUTCDate(monday.getUTCDate() + 7)
-    return {
-      from: monday.toISOString().slice(0, 10),
-      to: nextMonday.toISOString().slice(0, 10),
-      label: `${formatShortDate(monday.toISOString().slice(0, 10))} – ${formatShortDate(new Date(nextMonday.getTime() - 86400000).toISOString().slice(0, 10))}`,
-    }
-  }
+  const { from, to } = calendarPeriodBounds(period)
   if (period === 'YEARLY') {
-    const year = today.getUTCFullYear()
-    return {
-      from: `${year}-01-01`,
-      to: `${year + 1}-01-01`,
-      label: String(year),
-    }
+    return { from, to, label: from.slice(0, 4) }
   }
-  // MONTHLY: calendar month
-  const year = today.getUTCFullYear()
-  const month = today.getUTCMonth()
-  const from = new Date(Date.UTC(year, month, 1))
-  const to = new Date(Date.UTC(year, month + 1, 1))
-  const toDisplay = new Date(to.getTime() - 86400000)
   return {
-    from: from.toISOString().slice(0, 10),
-    to: to.toISOString().slice(0, 10),
-    label: `${formatShortDate(from.toISOString().slice(0, 10))} – ${formatShortDate(toDisplay.toISOString().slice(0, 10))}`,
+    from,
+    to,
+    label: `${formatShortDate(from)} – ${formatShortDate(addDaysToDateStr(to, -1))}`,
   }
 }
 
 function calendarDaysLeft(toExclusive: string): number {
-  const today = new Date().toISOString().slice(0, 10)
-  const a = new Date(today + 'T12:00:00Z').getTime()
-  const b = new Date(toExclusive + 'T12:00:00Z').getTime()
-  return Math.max(0, Math.round((b - a) / 86400000))
+  return Math.max(
+    0,
+    daysBetweenDateStr(new Date().toISOString().slice(0, 10), toExclusive)
+  )
 }
 
 export function TrackersSection({

--- a/src/lib/dateStr.test.ts
+++ b/src/lib/dateStr.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect } from 'vitest'
+import {
+  normalizeDateStr,
+  addDaysToDateStr,
+  daysBetweenDateStr,
+  calendarPeriodBounds,
+} from './dateStr'
+
+describe('normalizeDateStr', () => {
+  it('trims a datetime string to its date part', () => {
+    expect(normalizeDateStr('2026-02-11T08:30:00.000Z')).toBe('2026-02-11')
+  })
+  it('leaves a bare date untouched', () => {
+    expect(normalizeDateStr('2026-02-11')).toBe('2026-02-11')
+  })
+})
+
+describe('addDaysToDateStr', () => {
+  it('crosses a month boundary forward', () => {
+    expect(addDaysToDateStr('2026-01-31', 1)).toBe('2026-02-01')
+  })
+  it('crosses a month boundary backward (the -1 "display period end" case)', () => {
+    expect(addDaysToDateStr('2026-03-01', -1)).toBe('2026-02-28')
+  })
+  it('crosses a year boundary in both directions', () => {
+    expect(addDaysToDateStr('2025-12-31', 1)).toBe('2026-01-01')
+    expect(addDaysToDateStr('2026-01-01', -1)).toBe('2025-12-31')
+  })
+  it('lands on Feb 29 in a leap year', () => {
+    expect(addDaysToDateStr('2024-02-28', 1)).toBe('2024-02-29')
+    expect(addDaysToDateStr('2024-03-01', -1)).toBe('2024-02-29')
+  })
+  it('is a no-op for 0 days and normalizes datetime input', () => {
+    expect(addDaysToDateStr('2026-02-11T23:59:00Z', 0)).toBe('2026-02-11')
+  })
+  it('handles multi-week jumps', () => {
+    expect(addDaysToDateStr('2026-02-11', 21)).toBe('2026-03-04')
+  })
+})
+
+describe('daysBetweenDateStr', () => {
+  it('is 0 for the same day', () => {
+    expect(daysBetweenDateStr('2026-03-10', '2026-03-10')).toBe(0)
+  })
+  it('counts a forward span', () => {
+    expect(daysBetweenDateStr('2026-03-10', '2026-03-17')).toBe(7)
+  })
+  it('is negative when b precedes a', () => {
+    expect(daysBetweenDateStr('2026-03-17', '2026-03-10')).toBe(-7)
+  })
+  it('spans a month/year boundary', () => {
+    expect(daysBetweenDateStr('2025-12-25', '2026-01-05')).toBe(11)
+  })
+  it('ignores the time part of datetime strings', () => {
+    expect(
+      daysBetweenDateStr('2026-03-10T00:00:00Z', '2026-03-17T23:59:00Z')
+    ).toBe(7)
+  })
+  it('returns 0 when a side does not parse', () => {
+    expect(daysBetweenDateStr('not-a-date', '2026-03-10')).toBe(0)
+  })
+})
+
+describe('calendarPeriodBounds', () => {
+  // 2026-02-11 is a Wednesday; 2026-02-08 is a Sunday.
+  const wed = new Date('2026-02-11T09:00:00Z')
+  const sun = new Date('2026-02-08T09:00:00Z')
+
+  it('WEEKLY snaps to the enclosing Mon–Mon range', () => {
+    expect(calendarPeriodBounds('WEEKLY', 0, wed)).toEqual({
+      from: '2026-02-09',
+      to: '2026-02-16',
+    })
+  })
+  it('WEEKLY treats Sunday as the last day of its week, not the first', () => {
+    expect(calendarPeriodBounds('WEEKLY', 0, sun)).toEqual({
+      from: '2026-02-02',
+      to: '2026-02-09',
+    })
+  })
+  it('WEEKLY offset walks whole weeks back', () => {
+    expect(calendarPeriodBounds('WEEKLY', -1, wed)).toEqual({
+      from: '2026-02-02',
+      to: '2026-02-09',
+    })
+  })
+
+  it('MONTHLY is the calendar month, exclusive end', () => {
+    expect(calendarPeriodBounds('MONTHLY', 0, wed)).toEqual({
+      from: '2026-02-01',
+      to: '2026-03-01',
+    })
+  })
+  it('MONTHLY offset rolls the year backward', () => {
+    expect(calendarPeriodBounds('MONTHLY', -2, wed)).toEqual({
+      from: '2025-12-01',
+      to: '2026-01-01',
+    })
+  })
+  it('MONTHLY offset rolls the year forward', () => {
+    expect(calendarPeriodBounds('MONTHLY', 11, wed)).toEqual({
+      from: '2027-01-01',
+      to: '2027-02-01',
+    })
+  })
+
+  it('YEARLY spans Jan 1 to next Jan 1', () => {
+    expect(calendarPeriodBounds('YEARLY', 0, wed)).toEqual({
+      from: '2026-01-01',
+      to: '2027-01-01',
+    })
+    expect(calendarPeriodBounds('YEARLY', -1, wed)).toEqual({
+      from: '2025-01-01',
+      to: '2026-01-01',
+    })
+  })
+})

--- a/src/lib/dateStr.ts
+++ b/src/lib/dateStr.ts
@@ -1,0 +1,68 @@
+/**
+ * `YYYY-MM-DD` date-string arithmetic — the month/day/year-rollover math that
+ * `CLAUDE.md` calls out as historically bug-prone (unpadded dates, month
+ * rollover, DST). All of it anchors at noon UTC so a `+/- days` step never
+ * lands on a DST boundary, and every result is a plain `YYYY-MM-DD` string.
+ *
+ * Payday-relative logic still belongs to `@/lib/payday`; this module is the
+ * calendar-arithmetic layer shared by the tracker views and `services/trackers`.
+ */
+import type { BudgetDisplayPeriod } from './monthlyEquivalent'
+
+/** Trim a date-or-datetime string down to its leading `YYYY-MM-DD`. */
+export function normalizeDateStr(s: string): string {
+  return s.length >= 10 ? s.slice(0, 10) : s
+}
+
+/** Add `days` (may be negative) to a `YYYY-MM-DD` string, same form back. */
+export function addDaysToDateStr(dateStr: string, days: number): string {
+  const d = new Date(normalizeDateStr(dateStr) + 'T12:00:00Z')
+  d.setUTCDate(d.getUTCDate() + days)
+  return d.toISOString().slice(0, 10)
+}
+
+/**
+ * Whole days from `a` to `b` (`b - a`), rounded. Returns 0 if either side
+ * doesn't parse. Negative when `b` precedes `a`.
+ */
+export function daysBetweenDateStr(a: string, b: string): number {
+  const ta = new Date(normalizeDateStr(a) + 'T12:00:00Z').getTime()
+  const tb = new Date(normalizeDateStr(b) + 'T12:00:00Z').getTime()
+  if (Number.isNaN(ta) || Number.isNaN(tb)) return 0
+  return Math.round((tb - ta) / (24 * 60 * 60 * 1000))
+}
+
+/**
+ * Calendar bounds for a display period relative to `now`, `offset` periods
+ * away (0 = the current one, -1 = the previous, etc.). `from` is inclusive,
+ * `to` is exclusive (the first day of the next period). Weeks start Monday.
+ */
+export function calendarPeriodBounds(
+  period: BudgetDisplayPeriod,
+  offset = 0,
+  now: Date = new Date()
+): { from: string; to: string } {
+  const iso = (d: Date) => d.toISOString().slice(0, 10)
+
+  if (period === 'WEEKLY') {
+    const daysFromMonday = (now.getUTCDay() + 6) % 7
+    const from = new Date(now)
+    from.setUTCDate(now.getUTCDate() - daysFromMonday + offset * 7)
+    const to = new Date(from)
+    to.setUTCDate(from.getUTCDate() + 7)
+    return { from: iso(from), to: iso(to) }
+  }
+
+  if (period === 'YEARLY') {
+    const year = now.getUTCFullYear() + offset
+    return { from: `${year}-01-01`, to: `${year + 1}-01-01` }
+  }
+
+  // MONTHLY — calendar month
+  const year = now.getUTCFullYear()
+  const month = now.getUTCMonth()
+  return {
+    from: iso(new Date(Date.UTC(year, month + offset, 1))),
+    to: iso(new Date(Date.UTC(year, month + offset + 1, 1))),
+  }
+}

--- a/src/pages/analytics/AnalyticsTrackers.tsx
+++ b/src/pages/analytics/AnalyticsTrackers.tsx
@@ -12,6 +12,7 @@ import {
   type BudgetDisplayPeriod,
 } from '@/lib/monthlyEquivalent'
 import { formatMoney, formatShortDate } from '@/lib/format'
+import { addDaysToDateStr, calendarPeriodBounds } from '@/lib/dateStr'
 import { syncStore } from '@/stores/syncStore'
 
 const RESET_FREQUENCIES: { value: TrackerResetFrequency; label: string }[] = [
@@ -39,46 +40,20 @@ function getCalendarPeriodBounds(period: BudgetDisplayPeriod): {
   to: string
   label: string
 } {
-  const today = new Date()
-  if (period === 'WEEKLY') {
-    const day = today.getUTCDay()
-    const daysFromMonday = (day + 6) % 7
-    const monday = new Date(today)
-    monday.setUTCDate(today.getUTCDate() - daysFromMonday)
-    const nextMonday = new Date(monday)
-    nextMonday.setUTCDate(monday.getUTCDate() + 7)
-    return {
-      from: monday.toISOString().slice(0, 10),
-      to: nextMonday.toISOString().slice(0, 10),
-      label: `${formatShortDate(monday.toISOString().slice(0, 10))} – ${formatShortDate(new Date(nextMonday.getTime() - 86400000).toISOString().slice(0, 10))}`,
-    }
-  }
+  const { from, to } = calendarPeriodBounds(period)
   if (period === 'YEARLY') {
-    const year = today.getUTCFullYear()
-    return {
-      from: `${year}-01-01`,
-      to: `${year + 1}-01-01`,
-      label: String(year),
-    }
+    return { from, to, label: from.slice(0, 4) }
   }
-  // MONTHLY: calendar month
-  const year = today.getUTCFullYear()
-  const month = today.getUTCMonth()
-  const from = new Date(Date.UTC(year, month, 1))
-  const to = new Date(Date.UTC(year, month + 1, 1))
-  const toDisplay = new Date(to.getTime() - 86400000)
   return {
-    from: from.toISOString().slice(0, 10),
-    to: to.toISOString().slice(0, 10),
-    label: `${formatShortDate(from.toISOString().slice(0, 10))} – ${formatShortDate(toDisplay.toISOString().slice(0, 10))}`,
+    from,
+    to,
+    label: `${formatShortDate(from)} – ${formatShortDate(addDaysToDateStr(to, -1))}`,
   }
 }
 
 // period_end from tracker is exclusive — subtract one day for display.
 function displayPeriodEnd(isoDate: string): string {
-  const d = new Date(isoDate + 'T12:00:00Z')
-  d.setUTCDate(d.getUTCDate() - 1)
-  return d.toISOString().slice(0, 10)
+  return addDaysToDateStr(isoDate, -1)
 }
 
 function getTrackerProgressStyle(progress: number): {

--- a/src/pages/analytics/AnalyticsTrackersDetail.tsx
+++ b/src/pages/analytics/AnalyticsTrackersDetail.tsx
@@ -27,6 +27,11 @@ import {
 } from '@/lib/monthlyEquivalent'
 import { getCategories } from '@/services/categories'
 import { formatMoney, formatDate, formatShortDate } from '@/lib/format'
+import {
+  addDaysToDateStr,
+  calendarPeriodBounds,
+  daysBetweenDateStr,
+} from '@/lib/dateStr'
 import { TrackerHistoryChart } from '@/components/charts/TrackerHistoryChart'
 import { TrackerPaceChart } from '@/components/charts/TrackerPaceChart'
 import { useMediaQuery } from '@/hooks/useMediaQuery'
@@ -47,19 +52,11 @@ const PERIOD_OPTIONS = [
 
 const PAGE_SIZE = 20
 
-function daysBetween(a: string, b: string): number {
-  return Math.round(
-    (new Date(b.slice(0, 10) + 'T12:00:00Z').getTime() -
-      new Date(a.slice(0, 10) + 'T12:00:00Z').getTime()) /
-      86400000
-  )
-}
+const daysBetween = daysBetweenDateStr
 
 // period_end is exclusive (first day of next period) — subtract one day for display.
 function displayPeriodEnd(isoDate: string): string {
-  const d = new Date(isoDate + 'T12:00:00Z')
-  d.setUTCDate(d.getUTCDate() - 1)
-  return d.toISOString().slice(0, 10)
+  return addDaysToDateStr(isoDate, -1)
 }
 
 function buildCalendarPeriodHistory(
@@ -78,19 +75,10 @@ function buildCalendarPeriodHistory(
   const result: TrackerPeriodHistoryRow[] = []
 
   for (let offset = -periodsBack + 1; offset <= 0; offset++) {
-    let from: string
-    let to: string // exclusive
+    const { from, to } = calendarPeriodBounds(displayPeriod, offset, today)
     let label: string
 
     if (displayPeriod === 'WEEKLY') {
-      const day = today.getUTCDay()
-      const daysFromMonday = (day + 6) % 7
-      const mon = new Date(today)
-      mon.setUTCDate(today.getUTCDate() - daysFromMonday + offset * 7)
-      const nextMon = new Date(mon)
-      nextMon.setUTCDate(mon.getUTCDate() + 7)
-      from = mon.toISOString().slice(0, 10)
-      to = nextMon.toISOString().slice(0, 10)
       label =
         offset === 0
           ? 'This week'
@@ -98,12 +86,6 @@ function buildCalendarPeriodHistory(
             ? 'Last week'
             : `${-offset} weeks ago`
     } else if (displayPeriod === 'MONTHLY') {
-      const baseYear = today.getUTCFullYear()
-      const baseMonth = today.getUTCMonth() + offset
-      const fromDate = new Date(Date.UTC(baseYear, baseMonth, 1))
-      const toDate = new Date(Date.UTC(baseYear, baseMonth + 1, 1))
-      from = fromDate.toISOString().slice(0, 10)
-      to = toDate.toISOString().slice(0, 10)
       label =
         offset === 0
           ? 'Current'
@@ -112,10 +94,7 @@ function buildCalendarPeriodHistory(
             : `${-offset} months ago`
     } else {
       // YEARLY
-      const year = today.getUTCFullYear() + offset
-      from = `${year}-01-01`
-      to = `${year + 1}-01-01`
-      label = offset === 0 ? 'Current' : String(year)
+      label = offset === 0 ? 'Current' : from.slice(0, 4)
     }
 
     const spent = getTrackerSpentInPeriod(trackerId, from, to)

--- a/src/services/trackers.ts
+++ b/src/services/trackers.ts
@@ -5,6 +5,11 @@
 import { getDb, getAppSetting, schedulePersist } from '@/db'
 import { previousPaydayDate, type PaydayFrequency } from '@/lib/payday'
 import { localDateString } from '@/lib/format'
+import {
+  addDaysToDateStr,
+  daysBetweenDateStr,
+  normalizeDateStr,
+} from '@/lib/dateStr'
 
 export type TrackerResetFrequency =
   | 'WEEKLY'
@@ -70,22 +75,10 @@ export function getTrackersList(): TrackerListRow[] {
   return list
 }
 
-function daysBetween(dateStrA: string, dateStrB: string): number {
-  const norm = (s: string) => (s.length >= 10 ? s.slice(0, 10) : s)
-  const a = new Date(norm(dateStrA) + 'T12:00:00Z').getTime()
-  const b = new Date(norm(dateStrB) + 'T12:00:00Z').getTime()
-  if (Number.isNaN(a) || Number.isNaN(b)) return 0
-  return Math.round((b - a) / (24 * 60 * 60 * 1000))
-}
-
-const normDate = (s: string) => (s.length >= 10 ? s.slice(0, 10) : s)
-
-/** Add `days` (may be negative) to a 'YYYY-MM-DD' string, returning the same form. */
-function addDaysToDateStr(dateStr: string, days: number): string {
-  const d = new Date(normDate(dateStr) + 'T12:00:00Z')
-  d.setUTCDate(d.getUTCDate() + days)
-  return d.toISOString().slice(0, 10)
-}
+// Calendar date-string arithmetic lives in @/lib/dateStr; these aliases keep
+// the call sites (and the __test__ export) in this file unchanged.
+const daysBetween = daysBetweenDateStr
+const normDate = normalizeDateStr
 
 /** Same category set, order-insensitive. */
 function sameCategorySet(a: string[], b: string[]): boolean {


### PR DESCRIPTION
Closes #11. Part of the #1 codebase-design deepening map — the "investigate raw `new Date()` arithmetic" ticket. **Investigation outcome: genuine duplication found → extracted.**

## What the audit found
| Site | Verdict |
|------|---------|
| `displayPeriodEnd()` in TrackersSection / AnalyticsTrackers / AnalyticsTrackersDetail | **byte-identical triplication** — it's `addDaysToDateStr(x, -1)` |
| `getCalendarPeriodBounds()` in TrackersSection / AnalyticsTrackers | **byte-identical duplication** |
| `buildCalendarPeriodHistory()` in AnalyticsTrackersDetail | same Monday-week / calendar-month UTC bounds, parameterised by an offset |
| days-between-date-strings: `calendarDaysLeft` (TrackersSection), `daysBetween` (AnalyticsTrackersDetail), private `daysBetween` (`services/trackers.ts`) | **triplication** |
| `UpcomingSection.calcNextChargeDate` | **buggy** reimplementation of `services/upcoming.ts`'s occurrence logic (month-end overflow: Jan 31 +1mo → Mar 3) → **filed as #47**, fixed separately |
| inline `localDateString`-style "today" formatting (Dashboard, UpcomingSection); calendar-grid rendering math; sync-age ms; month-name header; Savers month-diff | **genuinely local** — ticket says date-display formatting is fine as-is |

## Change
New **`src/lib/dateStr.ts`**:
- `normalizeDateStr`, `addDaysToDateStr`, `daysBetweenDateStr` — moved out of `services/trackers.ts` (which now imports them, aliased so its call sites and `__test__` export are untouched).
- `calendarPeriodBounds(period, offset = 0, now = new Date()) → { from, to }` — inclusive `from`, exclusive `to`, Monday-start weeks. The three tracker views keep only their own label strings, built from the shared bounds.

**Behaviour unchanged** — the arithmetic is identical, just relocated. Net −74 lines across the four existing files.

## Tests
`src/lib/dateStr.test.ts` (21): month/year rollover both directions, leap-year Feb 29, datetime-input normalisation, negative + NaN spans, WEEKLY Monday-snap including the Sunday edge (`(day + 6) % 7`), MONTHLY/YEARLY offset year-rollover. Existing `trackers.test.ts` (`__test__.daysBetween`) still passes unchanged.

## Verification
`npm run validate` clean (0 errors); full unit suite **521 passing**.