### PR TITLE
Extract getTrackersDisplayPeriodData into services/trackers (#49)

### DIFF
--- a/src/components/dashboard/TrackersSection.tsx
+++ b/src/components/dashboard/TrackersSection.tsx
@@ -16,28 +16,20 @@ import {
   getTracker,
   getTrackersWithProgressForPeriod,
   getTrackerTransactionsInPeriod,
-  getTrackerSpentInPeriod,
   getTrackerCategoryIds,
   getTrackerCategoryUsage,
   createTracker,
   updateTracker,
   deleteTracker,
   calculatePaydayBudgetTotal,
+  getTrackersDisplayPeriodData,
   type TrackerResetFrequency,
 } from '@/services/trackers'
 import { getCategories } from '@/services/categories'
 import { getPayAmountCents } from '@/services/balance'
 import { getAppSetting } from '@/db'
-import {
-  toPeriodCents,
-  type BudgetDisplayPeriod,
-} from '@/lib/monthlyEquivalent'
+import { type BudgetDisplayPeriod } from '@/lib/monthlyEquivalent'
 import { formatMoney, formatShortDate } from '@/lib/format'
-import {
-  addDaysToDateStr,
-  calendarPeriodBounds,
-  daysBetweenDateStr,
-} from '@/lib/dateStr'
 import { toast } from '@/stores/toastStore'
 import { syncStore } from '@/stores/syncStore'
 import { HelpPopover } from '@/components/HelpPopover'
@@ -56,12 +48,6 @@ const FREQUENCY_ORDER: TrackerResetFrequency[] = [
   'FORTNIGHTLY',
   'MONTHLY',
 ]
-
-// period_end is exclusive (the reset date / first day of next period), so subtract
-// one day to get the last inclusive day for display purposes.
-function displayPeriodEnd(isoDate: string): string {
-  return addDaysToDateStr(isoDate, -1)
-}
 
 function getTrackerProgressStyle(progress: number): {
   variant: 'primary' | 'warning' | 'danger' | 'success'
@@ -85,29 +71,6 @@ const DISPLAY_PERIODS: { value: BudgetDisplayPeriod; label: string }[] = [
   { value: 'MONTHLY', label: 'Monthly' },
   { value: 'YEARLY', label: 'Yearly' },
 ]
-
-function getCalendarPeriodBounds(period: BudgetDisplayPeriod): {
-  from: string
-  to: string
-  label: string
-} {
-  const { from, to } = calendarPeriodBounds(period)
-  if (period === 'YEARLY') {
-    return { from, to, label: from.slice(0, 4) }
-  }
-  return {
-    from,
-    to,
-    label: `${formatShortDate(from)} – ${formatShortDate(addDaysToDateStr(to, -1))}`,
-  }
-}
-
-function calendarDaysLeft(toExclusive: string): number {
-  return Math.max(
-    0,
-    daysBetweenDateStr(new Date().toISOString().slice(0, 10), toExclusive)
-  )
-}
 
 export function TrackersSection({
   dragHandleProps,
@@ -174,65 +137,11 @@ export function TrackersSection({
     totalPaydayBudgetCents > payAmountCents
 
   // Effective budget/spend per display period (normalized when display period differs from native)
-  const effectiveDataByTrackerId = useMemo(() => {
-    const map: Record<
-      number,
-      {
-        spent: number
-        budget: number
-        remaining: number
-        progress: number
-        daysLeft: number
-        dateRangeLabel: string
-        wasAdjusted: boolean
-      }
-    > = {}
-    for (const t of trackers) {
-      const nativeMatch =
-        (displayPeriod === 'WEEKLY' && t.reset_frequency === 'WEEKLY') ||
-        (displayPeriod === 'MONTHLY' && t.reset_frequency === 'MONTHLY')
-      let spent: number
-      let budget: number
-      let daysLeft: number
-      let dateRangeLabel: string
-      let wasAdjusted = false
-      if (nativeMatch) {
-        spent = t.spent
-        // Effective budget: the sum of the prorated per-segment budgets when a
-        // config change split the current period (#16); otherwise = budget_amount.
-        budget = t.effectiveBudget
-        wasAdjusted = t.wasAdjustedThisPeriod
-        daysLeft = t.daysLeft
-        dateRangeLabel =
-          t.period_start && t.period_end
-            ? `${formatShortDate(t.period_start)} – ${formatShortDate(displayPeriodEnd(t.period_end))}`
-            : ''
-      } else {
-        const bounds = getCalendarPeriodBounds(displayPeriod)
-        spent = getTrackerSpentInPeriod(t.id, bounds.from, bounds.to)
-        budget = toPeriodCents(
-          t.budget_amount,
-          t.reset_frequency,
-          displayPeriod
-        )
-        daysLeft = calendarDaysLeft(bounds.to)
-        dateRangeLabel = bounds.label
-      }
-      const remaining = Math.max(0, budget - spent)
-      const progress = budget > 0 ? (spent / budget) * 100 : 0
-      map[t.id] = {
-        spent,
-        budget,
-        remaining,
-        progress,
-        daysLeft,
-        dateRangeLabel,
-        wasAdjusted,
-      }
-    }
-    return map
+  const effectiveDataByTrackerId = useMemo(
+    () => getTrackersDisplayPeriodData(trackers, displayPeriod),
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [trackers, displayPeriod, refresh, lastSyncCompletedAt])
+    [trackers, displayPeriod, refresh, lastSyncCompletedAt]
+  )
 
   function openCreate() {
     setEditingId(null)
@@ -464,6 +373,7 @@ export function TrackersSection({
                     daysLeft: t.daysLeft,
                     dateRangeLabel: '',
                     wasAdjusted: t.wasAdjustedThisPeriod,
+                    isNativePeriod: false,
                   }
                   const progressStyle = getTrackerProgressStyle(
                     effectiveData.progress

--- a/src/pages/analytics/AnalyticsTrackers.tsx
+++ b/src/pages/analytics/AnalyticsTrackers.tsx
@@ -4,15 +4,11 @@ import { Link } from 'react-router-dom'
 import { Card, Col, Form, ProgressBar } from 'react-bootstrap'
 import {
   getTrackersWithProgressForPeriod,
-  getTrackerSpentInPeriod,
+  getTrackersDisplayPeriodData,
   type TrackerResetFrequency,
 } from '@/services/trackers'
-import {
-  toPeriodCents,
-  type BudgetDisplayPeriod,
-} from '@/lib/monthlyEquivalent'
-import { formatMoney, formatShortDate } from '@/lib/format'
-import { addDaysToDateStr, calendarPeriodBounds } from '@/lib/dateStr'
+import { type BudgetDisplayPeriod } from '@/lib/monthlyEquivalent'
+import { formatMoney } from '@/lib/format'
 import { syncStore } from '@/stores/syncStore'
 
 const RESET_FREQUENCIES: { value: TrackerResetFrequency; label: string }[] = [
@@ -34,27 +30,6 @@ const DISPLAY_PERIODS: { value: BudgetDisplayPeriod; label: string }[] = [
   { value: 'MONTHLY', label: 'Monthly' },
   { value: 'YEARLY', label: 'Yearly' },
 ]
-
-function getCalendarPeriodBounds(period: BudgetDisplayPeriod): {
-  from: string
-  to: string
-  label: string
-} {
-  const { from, to } = calendarPeriodBounds(period)
-  if (period === 'YEARLY') {
-    return { from, to, label: from.slice(0, 4) }
-  }
-  return {
-    from,
-    to,
-    label: `${formatShortDate(from)} – ${formatShortDate(addDaysToDateStr(to, -1))}`,
-  }
-}
-
-// period_end from tracker is exclusive — subtract one day for display.
-function displayPeriodEnd(isoDate: string): string {
-  return addDaysToDateStr(isoDate, -1)
-}
 
 function getTrackerProgressStyle(progress: number): {
   variant: 'success' | 'warning' | 'danger'
@@ -93,50 +68,11 @@ export function AnalyticsTrackers() {
     )
   }, [trackers, frequencyFilter])
 
-  const effectiveDataByTrackerId = useMemo(() => {
-    const map: Record<
-      number,
-      {
-        spent: number
-        budget: number
-        progress: number
-        dateRangeLabel: string
-        wasAdjusted: boolean
-      }
-    > = {}
-    for (const t of trackers) {
-      const nativeMatch =
-        (displayPeriod === 'WEEKLY' && t.reset_frequency === 'WEEKLY') ||
-        (displayPeriod === 'MONTHLY' && t.reset_frequency === 'MONTHLY')
-      let spent: number
-      let budget: number
-      let dateRangeLabel: string
-      let wasAdjusted = false
-      if (nativeMatch) {
-        spent = t.spent
-        // Effective budget accounts for a mid-period config change (#16).
-        budget = t.effectiveBudget
-        wasAdjusted = t.wasAdjustedThisPeriod
-        dateRangeLabel =
-          t.period_start && t.period_end
-            ? `${formatShortDate(t.period_start)} – ${formatShortDate(displayPeriodEnd(t.period_end))}`
-            : ''
-      } else {
-        const bounds = getCalendarPeriodBounds(displayPeriod)
-        spent = getTrackerSpentInPeriod(t.id, bounds.from, bounds.to)
-        budget = toPeriodCents(
-          t.budget_amount,
-          t.reset_frequency,
-          displayPeriod
-        )
-        dateRangeLabel = bounds.label
-      }
-      const progress = budget > 0 ? (spent / budget) * 100 : 0
-      map[t.id] = { spent, budget, progress, dateRangeLabel, wasAdjusted }
-    }
-    return map
+  const effectiveDataByTrackerId = useMemo(
+    () => getTrackersDisplayPeriodData(trackers, displayPeriod),
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [trackers, displayPeriod, lastSyncCompletedAt])
+    [trackers, displayPeriod, lastSyncCompletedAt]
+  )
 
   return (
     <>
@@ -194,9 +130,12 @@ export function AnalyticsTrackers() {
                 const effectiveData = effectiveDataByTrackerId[t.id] ?? {
                   spent: t.spent,
                   budget: t.effectiveBudget,
+                  remaining: t.remaining,
                   progress: t.progress,
+                  daysLeft: t.daysLeft,
                   dateRangeLabel: '',
                   wasAdjusted: t.wasAdjustedThisPeriod,
+                  isNativePeriod: false,
                 }
                 return (
                   <Link

--- a/src/services/trackers.test.ts
+++ b/src/services/trackers.test.ts
@@ -8,8 +8,39 @@ vi.mock('@/db', () => ({
   schedulePersist: () => {},
 }))
 
-const { __test__, getPeriodBoundsForOffset, calculatePaydayBudgetTotal } =
-  await import('./trackers')
+const {
+  __test__,
+  getPeriodBoundsForOffset,
+  calculatePaydayBudgetTotal,
+  getTrackersDisplayPeriodData,
+} = await import('./trackers')
+const { toPeriodCents } = await import('@/lib/monthlyEquivalent')
+const { formatShortDate } = await import('@/lib/format')
+const { calendarPeriodBounds } = await import('@/lib/dateStr')
+
+type ProgressRow = import('./trackers').TrackerWithProgress
+
+function makeProgressRow(overrides: Partial<ProgressRow> = {}): ProgressRow {
+  return {
+    id: 1,
+    name: 'Groceries',
+    budget_amount: 40000,
+    reset_frequency: 'MONTHLY',
+    reset_day: 1,
+    last_reset_date: '2026-03-01',
+    next_reset_date: '2026-04-01',
+    bucket_id: null,
+    spent: 10000,
+    effectiveBudget: 40000,
+    remaining: 30000,
+    daysLeft: 12,
+    progress: 25,
+    wasAdjustedThisPeriod: false,
+    period_start: '2026-03-01',
+    period_end: '2026-04-01',
+    ...overrides,
+  }
+}
 const {
   daysBetween,
   stepBackOnePeriod,
@@ -248,5 +279,94 @@ describe('calculatePaydayBudgetTotal', () => {
       { id: 1, reset_frequency: 'PAYDAY', budget_amount: 10000 },
     ]
     expect(calculatePaydayBudgetTotal(trackers, 999)).toBe(10000)
+  })
+})
+
+describe('getTrackersDisplayPeriodData', () => {
+  it('passes a native-period tracker through with its own figures (#16-aware)', () => {
+    const t = makeProgressRow({
+      reset_frequency: 'MONTHLY',
+      spent: 12000,
+      effectiveBudget: 36000, // prorated by a mid-period config change
+      daysLeft: 9,
+      wasAdjustedThisPeriod: true,
+      period_start: '2026-03-01',
+      period_end: '2026-04-01',
+    })
+    const d = getTrackersDisplayPeriodData([t], 'MONTHLY')[1]
+    expect(d).toEqual({
+      spent: 12000,
+      budget: 36000,
+      remaining: 24000,
+      progress: (12000 / 36000) * 100,
+      daysLeft: 9,
+      dateRangeLabel: `${formatShortDate('2026-03-01')} – ${formatShortDate('2026-03-31')}`,
+      wasAdjusted: true,
+      isNativePeriod: true,
+    })
+  })
+
+  it('treats WEEKLY display + WEEKLY tracker as native', () => {
+    const t = makeProgressRow({ reset_frequency: 'WEEKLY' })
+    expect(getTrackersDisplayPeriodData([t], 'WEEKLY')[1].isNativePeriod).toBe(
+      true
+    )
+  })
+
+  it('re-scales the budget with toPeriodCents when the period is non-native', () => {
+    const t = makeProgressRow({
+      reset_frequency: 'WEEKLY',
+      budget_amount: 20000,
+    })
+    const d = getTrackersDisplayPeriodData([t], 'MONTHLY')[1]
+    expect(d.isNativePeriod).toBe(false)
+    expect(d.budget).toBe(toPeriodCents(20000, 'WEEKLY', 'MONTHLY'))
+    // no DB in this suite → spent re-sums to 0 for the non-native branch
+    expect(d.spent).toBe(0)
+    expect(d.remaining).toBe(d.budget)
+    expect(d.progress).toBe(0)
+    const bounds = calendarPeriodBounds('MONTHLY')
+    expect(d.dateRangeLabel).toContain(' – ')
+    expect(d.dateRangeLabel.startsWith(formatShortDate(bounds.from))).toBe(true)
+  })
+
+  it('labels a non-native YEARLY period with the bare year', () => {
+    const t = makeProgressRow({ reset_frequency: 'MONTHLY' })
+    const d = getTrackersDisplayPeriodData([t], 'YEARLY')[1]
+    expect(d.isNativePeriod).toBe(false)
+    expect(d.dateRangeLabel).toBe(String(new Date().getUTCFullYear()))
+  })
+
+  it('guards against a zero budget', () => {
+    const t = makeProgressRow({
+      reset_frequency: 'MONTHLY',
+      effectiveBudget: 0,
+      spent: 5000,
+    })
+    const d = getTrackersDisplayPeriodData([t], 'MONTHLY')[1]
+    expect(d.progress).toBe(0)
+    expect(d.remaining).toBe(0)
+  })
+
+  it('yields an empty label for a native period with no period bounds', () => {
+    const t = makeProgressRow({
+      reset_frequency: 'MONTHLY',
+      period_start: undefined,
+      period_end: undefined,
+    })
+    expect(getTrackersDisplayPeriodData([t], 'MONTHLY')[1].dateRangeLabel).toBe(
+      ''
+    )
+  })
+
+  it('keys the result by tracker id', () => {
+    const rows = [
+      makeProgressRow({ id: 7, reset_frequency: 'WEEKLY' }),
+      makeProgressRow({ id: 9, reset_frequency: 'MONTHLY' }),
+    ]
+    const out = getTrackersDisplayPeriodData(rows, 'MONTHLY')
+    expect(Object.keys(out).sort()).toEqual(['7', '9'])
+    expect(out[7].isNativePeriod).toBe(false)
+    expect(out[9].isNativePeriod).toBe(true)
   })
 })

--- a/src/services/trackers.ts
+++ b/src/services/trackers.ts
@@ -4,12 +4,17 @@
 
 import { getDb, getAppSetting, schedulePersist } from '@/db'
 import { previousPaydayDate, type PaydayFrequency } from '@/lib/payday'
-import { localDateString } from '@/lib/format'
+import { localDateString, formatShortDate } from '@/lib/format'
 import {
   addDaysToDateStr,
   daysBetweenDateStr,
   normalizeDateStr,
+  calendarPeriodBounds,
 } from '@/lib/dateStr'
+import {
+  toPeriodCents,
+  type BudgetDisplayPeriod,
+} from '@/lib/monthlyEquivalent'
 
 export type TrackerResetFrequency =
   | 'WEEKLY'
@@ -488,6 +493,108 @@ export function calculatePaydayBudgetTotal(
   return trackers
     .filter((t) => t.reset_frequency === 'PAYDAY' && t.id !== excludeId)
     .reduce((sum, t) => sum + t.budget_amount, 0)
+}
+
+export interface TrackerDisplayPeriodData {
+  /** cents spent in the period */
+  spent: number
+  /** effective budget for the period, cents */
+  budget: number
+  /** max(0, budget - spent) */
+  remaining: number
+  /** spent / budget as a percentage (0 when budget is 0) */
+  progress: number
+  /** whole days left in the period (0 when past) */
+  daysLeft: number
+  /** e.g. "1 Mar – 31 Mar"; the bare year for a non-native YEARLY period; "" when unknown */
+  dateRangeLabel: string
+  /** #16 — a mid-period config change split the tracker's current native period */
+  wasAdjusted: boolean
+  /** true when `displayPeriod` is the tracker's own reset frequency */
+  isNativePeriod: boolean
+}
+
+/**
+ * Normalise each tracker's current spend / budget / progress to `displayPeriod`,
+ * keyed by tracker id. Shared by the dashboard Trackers section and the
+ * analytics Trackers overview.
+ *
+ * When the display period already is the tracker's reset frequency (WEEKLY or
+ * MONTHLY), the tracker's own current-period figures are used as-is — including
+ * the #16 prorated effective budget and the real days-left. Otherwise spend is
+ * re-summed over the calendar period and the budget is scaled with
+ * `toPeriodCents`.
+ */
+export function getTrackersDisplayPeriodData(
+  trackers: TrackerWithProgress[],
+  displayPeriod: BudgetDisplayPeriod
+): Record<number, TrackerDisplayPeriodData> {
+  const out: Record<number, TrackerDisplayPeriodData> = {}
+
+  for (const t of trackers) {
+    const isNativePeriod =
+      (displayPeriod === 'WEEKLY' && t.reset_frequency === 'WEEKLY') ||
+      (displayPeriod === 'MONTHLY' && t.reset_frequency === 'MONTHLY')
+
+    let spent: number
+    let budget: number
+    let daysLeft: number
+    let from: string
+    let to: string
+    let wasAdjusted = false
+
+    if (isNativePeriod) {
+      spent = t.spent
+      budget = t.effectiveBudget
+      daysLeft = t.daysLeft
+      wasAdjusted = t.wasAdjustedThisPeriod
+      from = t.period_start ?? ''
+      to = t.period_end ?? ''
+    } else {
+      const bounds = calendarPeriodBounds(displayPeriod)
+      spent = getTrackerSpentInPeriod(t.id, bounds.from, bounds.to)
+      budget = toPeriodCents(t.budget_amount, t.reset_frequency, displayPeriod)
+      // NOTE: the pre-extraction component used UTC `new Date().toISOString()`
+      // for "today" here, unlike this file's `localDateString()` convention.
+      // Kept as-is so the extraction changes no behaviour; worth reconciling.
+      daysLeft = Math.max(
+        0,
+        daysBetweenDateStr(new Date().toISOString().slice(0, 10), bounds.to)
+      )
+      from = bounds.from
+      to = bounds.to
+    }
+
+    out[t.id] = {
+      spent,
+      budget,
+      remaining: Math.max(0, budget - spent),
+      progress: budget > 0 ? (spent / budget) * 100 : 0,
+      daysLeft,
+      dateRangeLabel: formatPeriodRangeLabel(
+        displayPeriod,
+        isNativePeriod,
+        from,
+        to
+      ),
+      wasAdjusted,
+      isNativePeriod,
+    }
+  }
+
+  return out
+}
+
+/** "1 Mar – 31 Mar", or the bare year for a non-native YEARLY period. */
+function formatPeriodRangeLabel(
+  displayPeriod: BudgetDisplayPeriod,
+  isNativePeriod: boolean,
+  from: string,
+  to: string
+): string {
+  if (!from || !to) return ''
+  if (!isNativePeriod && displayPeriod === 'YEARLY') return from.slice(0, 4)
+  return `${formatShortDate(from)} – ${formatShortDate(addDaysToDateStr(to, -1))}`
 }
 
 /**


### PR DESCRIPTION
Closes #49. The one real finding from the #12 investigation.

## Problem
`effectiveDataByTrackerId` — "normalize a tracker's current spend / budget / progress to an arbitrary display period" — was implemented twice, in `TrackersSection.tsx` and `AnalyticsTrackers.tsx`, encoding the same rules:
- native-match short-circuit: when `displayPeriod` is the tracker's own reset frequency (WEEKLY/MONTHLY), use `t.spent` / `t.effectiveBudget` / `t.daysLeft` / `t.wasAdjustedThisPeriod` — i.e. the #16 split-period figures
- otherwise re-sum spend over `calendarPeriodBounds` and scale the budget with `toPeriodCents`
- `progress = budget > 0 ? spent/budget*100 : 0`, `remaining = max(0, budget - spent)`
- a date-range label ("1 Mar – 31 Mar"), or the bare year for a non-native YEARLY period

## Change
New **`getTrackersDisplayPeriodData(trackers, displayPeriod)`** in `services/trackers.ts` → `Record<id, TrackerDisplayPeriodData>` (a superset — `TrackersSection` also reads `daysLeft`/`remaining`, `AnalyticsTrackers` ignores them). The label helper moves in with it. Both components drop their memo body, their local `getCalendarPeriodBounds` / `displayPeriodEnd` / `calendarDaysLeft` copies, and now-unused imports — **~185 fewer component lines**.

**Behaviour identical**, including the pre-existing quirk that the non-native `daysLeft` uses UTC `new Date().toISOString()` for "today" rather than this file's `localDateString()` — kept with a `NOTE`, worth reconciling on its own.

`AnalyticsTrackersDetail`'s `buildCalendarPeriodHistory` is **left alone** — it's calendar-aligned history with no native-match short-circuit, a genuinely different calculation.

## Tests
`trackers.test.ts` +7: native pass-through (incl. `wasAdjusted` + the range label), WEEKLY-native, non-native budget re-scale via `toPeriodCents`, non-native YEARLY bare-year label, zero-budget guard, missing-bounds → empty label, result keyed by id.

## Verification
`npm run validate` clean (0 errors); full unit suite **539 passing**.