### PR TITLE
Count non-native tracker daysLeft from the local date, not UTC (#52)

### DIFF
--- a/src/services/trackers.test.ts
+++ b/src/services/trackers.test.ts
@@ -330,6 +330,21 @@ describe('getTrackersDisplayPeriodData', () => {
     expect(d.dateRangeLabel.startsWith(formatShortDate(bounds.from))).toBe(true)
   })
 
+  it('counts non-native daysLeft from the local date, not UTC (#52)', () => {
+    vi.useFakeTimers()
+    // noon UTC → the calendar date is the same in every timezone, so this
+    // pins the value; the point is that "today" comes from localDateString().
+    vi.setSystemTime(new Date('2026-03-15T12:00:00Z'))
+    try {
+      const t = makeProgressRow({ reset_frequency: 'WEEKLY' })
+      const d = getTrackersDisplayPeriodData([t], 'MONTHLY')[1]
+      // 2026-03-15 → 2026-04-01 (exclusive end of the calendar month)
+      expect(d.daysLeft).toBe(17)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
   it('labels a non-native YEARLY period with the bare year', () => {
     const t = makeProgressRow({ reset_frequency: 'MONTHLY' })
     const d = getTrackersDisplayPeriodData([t], 'YEARLY')[1]

--- a/src/services/trackers.ts
+++ b/src/services/trackers.ts
@@ -554,13 +554,7 @@ export function getTrackersDisplayPeriodData(
       const bounds = calendarPeriodBounds(displayPeriod)
       spent = getTrackerSpentInPeriod(t.id, bounds.from, bounds.to)
       budget = toPeriodCents(t.budget_amount, t.reset_frequency, displayPeriod)
-      // NOTE: the pre-extraction component used UTC `new Date().toISOString()`
-      // for "today" here, unlike this file's `localDateString()` convention.
-      // Kept as-is so the extraction changes no behaviour; worth reconciling.
-      daysLeft = Math.max(
-        0,
-        daysBetweenDateStr(new Date().toISOString().slice(0, 10), bounds.to)
-      )
+      daysLeft = Math.max(0, daysBetweenDateStr(localDateString(), bounds.to))
       from = bounds.from
       to = bounds.to
     }


### PR DESCRIPTION
Closes #52. Split out of the #51 (#49) code review.

## Problem
`getTrackersDisplayPeriodData`'s non-native branch computed days-left from `new Date().toISOString().slice(0, 10)` — **UTC** today — while everywhere else in `trackers.ts` "today" is `localDateString()`. For a user at UTC+10/+11 (every Up Bank customer) opening the app before ~10am local, UTC is still the previous calendar day, so `daysLeft` reads one higher than the truth — e.g. "13 days left" when 12 remain — on tracker cards whose display period isn't the tracker's native reset frequency.

Pre-existing (the dashboard component had this before #49 consolidated it); carried forward with a `NOTE` so the extraction changed no behaviour.

## Fix
One line: `localDateString()` instead of the UTC expression; `NOTE` removed. Native-branch `daysLeft` is untouched — it passes through `t.daysLeft`, which the service already computes with `localDateString()`.

## Tests
`trackers.test.ts` +1: `vi.setSystemTime` at a fixed instant, asserts `daysLeft` is the local day count (`2026-03-15` → `2026-04-01` = 17).

## Verification
`npm run validate` clean (0 errors); full unit suite **540 passing**.