### PR TITLE
Add a read-only Configuration history card to the tracker detail page (#37)

### DIFF
--- a/src/pages/analytics/AnalyticsTrackersDetail.tsx
+++ b/src/pages/analytics/AnalyticsTrackersDetail.tsx
@@ -27,7 +27,12 @@ import {
   type BudgetDisplayPeriod,
 } from '@/lib/monthlyEquivalent'
 import { getCategories } from '@/services/categories'
-import { formatMoney, formatDate, formatShortDate } from '@/lib/format'
+import {
+  formatMoney,
+  formatDate,
+  formatShortDate,
+  formatShortDateWithYear,
+} from '@/lib/format'
 import {
   addDaysToDateStr,
   calendarPeriodBounds,
@@ -252,10 +257,9 @@ export function AnalyticsTrackersDetail() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [tracker, id, lastSyncCompletedAt])
 
-  const categoryNameById = useMemo(
-    () => new Map(categories.map((c) => [c.id, c.name])),
-    [categories]
-  )
+  // `categories` is re-fetched unmemoized each render, so a useMemo keyed on it
+  // would rebuild every time anyway — just build the lookup inline.
+  const categoryNameById = new Map(categories.map((c) => [c.id, c.name]))
 
   const maxDomainPeriod = useMemo(() => {
     if (effectivePeriodHistory.length === 0) return undefined
@@ -516,7 +520,7 @@ export function AnalyticsTrackersDetail() {
                       {configHistory.map((v, i) => (
                         <tr key={v.id}>
                           <td>
-                            {formatShortDate(v.effective_from)}
+                            {formatShortDateWithYear(v.effective_from)}
                             {i === configHistory.length - 1 && (
                               <Badge bg="secondary" className="text-dark ms-2">
                                 Initial
@@ -528,7 +532,8 @@ export function AnalyticsTrackersDetail() {
                           </td>
                           <td className="small">
                             {v.category_ids
-                              .map((cid) => categoryNameById.get(cid) ?? cid)
+                              .map((cid) => categoryNameById.get(cid))
+                              .filter((n): n is string => n != null)
                               .sort((a, b) => a.localeCompare(b))
                               .join(', ') || '—'}
                           </td>

--- a/src/pages/analytics/AnalyticsTrackersDetail.tsx
+++ b/src/pages/analytics/AnalyticsTrackersDetail.tsx
@@ -18,6 +18,7 @@ import {
   getTrackerTransactionsForTable,
   getTrackerTransactionsCount,
   getTrackerCategoryIds,
+  getTrackerConfigHistory,
   type TrackerResetFrequency,
   type TrackerPeriodHistoryRow,
 } from '@/services/trackers'
@@ -241,6 +242,20 @@ export function AnalyticsTrackersDetail() {
     .map((cid) => categories.find((c) => c.id === cid)?.name)
     .filter(Boolean)
     .join(', ')
+
+  // #16 Phase 2 — read-only config timeline, newest first. A single genesis
+  // row means the tracker has never been reconfigured, so there's nothing to
+  // show; the card only appears once there's real history.
+  const configHistory = useMemo(() => {
+    if (!tracker) return []
+    return [...getTrackerConfigHistory(id)].reverse()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [tracker, id, lastSyncCompletedAt])
+
+  const categoryNameById = useMemo(
+    () => new Map(categories.map((c) => [c.id, c.name])),
+    [categories]
+  )
 
   const maxDomainPeriod = useMemo(() => {
     if (effectivePeriodHistory.length === 0) return undefined
@@ -474,6 +489,59 @@ export function AnalyticsTrackersDetail() {
           </Card>
         </Col>
       </Row>
+
+      {/* Configuration history (#16 Phase 2) */}
+      {configHistory.length > 1 && (
+        <Row className="grid-margin">
+          <Col xs={12}>
+            <Card>
+              <Card.Header>
+                <Card.Title className="mb-0">Configuration history</Card.Title>
+                <Card.Text as="div" className="small text-muted mt-1">
+                  How this tracker&rsquo;s budget and categories have changed
+                  over time, newest first.
+                </Card.Text>
+              </Card.Header>
+              <Card.Body className="p-0">
+                <div className="table-responsive">
+                  <table className="table table-striped mb-0">
+                    <thead>
+                      <tr>
+                        <th>Effective from</th>
+                        <th className="text-end">Budget</th>
+                        <th>Categories</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {configHistory.map((v, i) => (
+                        <tr key={v.id}>
+                          <td>
+                            {formatShortDate(v.effective_from)}
+                            {i === configHistory.length - 1 && (
+                              <Badge bg="secondary" className="text-dark ms-2">
+                                Initial
+                              </Badge>
+                            )}
+                          </td>
+                          <td className="text-end">
+                            ${formatMoney(v.budget_amount)}
+                          </td>
+                          <td className="small">
+                            {v.category_ids
+                              .map((cid) => categoryNameById.get(cid) ?? cid)
+                              .sort((a, b) => a.localeCompare(b))
+                              .join(', ') || '—'}
+                          </td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+              </Card.Body>
+            </Card>
+          </Col>
+        </Row>
+      )}
 
       {/* Spending Pace */}
       <Row className="grid-margin">


### PR DESCRIPTION
Closes #37. #16 Phase 2 / ADR-0014 — the read-only surface.

Phase 1 (`f86d607`) shipped `tracker_config_history` and the current-period split calc, but nothing surfaced the timeline.

## Change
`AnalyticsTrackersDetail` (`/analytics/trackers/:id`) gains a **"Configuration history"** card built from `getTrackerConfigHistory(id)`, **newest first**:
- `effective_from` (via `formatShortDate`)
- budget (`$` + `formatMoney`)
- category set — names resolved from `getCategories()`, sorted, `—` when empty

The oldest row carries an "Initial" badge. The card **only renders when there's more than one version** — a tracker that's never been reconfigured has just its genesis row, so there's nothing to compare and no card.

Additive UI, no calc changes. Table markup / `Badge` match the existing Transactions card on the same page.

## Tests
None added — the new code is view glue (reverse, gate, format); `getTrackerConfigHistory`'s ordering, category lists, genesis-row and multi-version behaviour are already covered in `trackerConfigHistory.test.ts`.

## Verification
`npm run validate` clean (0 errors); full unit suite **539 passing**.