### PR TITLE
Thread one consistent local "today" through non-native tracker period data (#52)

### DIFF
--- a/src/services/trackers.test.ts
+++ b/src/services/trackers.test.ts
@@ -334,7 +334,33 @@ describe('getTrackersDisplayPeriodData', () => {
     const t = makeProgressRow({ reset_frequency: 'MONTHLY' })
     const d = getTrackersDisplayPeriodData([t], 'YEARLY')[1]
     expect(d.isNativePeriod).toBe(false)
-    expect(d.dateRangeLabel).toBe(String(new Date().getUTCFullYear()))
+    // the non-native branch anchors on the local calendar date
+    expect(d.dateRangeLabel).toBe(String(new Date().getFullYear()))
+  })
+
+  it('threads one consistent local "today" through non-native bounds and daysLeft (#52)', () => {
+    const originalTz = process.env.TZ
+    // UTC+11 in March (Australian daylight saving) — every Up Bank customer is
+    // on an AU offset.
+    process.env.TZ = 'Australia/Sydney'
+    vi.useFakeTimers()
+    // 2026-03-31 14:00 UTC == 2026-04-01 01:00 in Sydney: UTC is still on
+    // March, the local calendar has already rolled into April.
+    vi.setSystemTime(new Date('2026-03-31T14:00:00Z'))
+    try {
+      const t = makeProgressRow({ reset_frequency: 'WEEKLY' })
+      const d = getTrackersDisplayPeriodData([t], 'MONTHLY')[1]
+      // Local "today" is 1 Apr, so the display period is the whole of April:
+      // 30 days left and an April label — not the "1 Mar – 31 Mar · 0 days
+      // left" mismatch a UTC "today" against local-derived bounds produces.
+      expect(d.daysLeft).toBe(30)
+      expect(d.dateRangeLabel).toBe(
+        `${formatShortDate('2026-04-01')} – ${formatShortDate('2026-04-30')}`
+      )
+    } finally {
+      vi.useRealTimers()
+      process.env.TZ = originalTz
+    }
   })
 
   it('guards against a zero budget', () => {

--- a/src/services/trackers.ts
+++ b/src/services/trackers.ts
@@ -531,6 +531,17 @@ export function getTrackersDisplayPeriodData(
 ): Record<number, TrackerDisplayPeriodData> {
   const out: Record<number, TrackerDisplayPeriodData> = {}
 
+  // One consistent "today" for the whole pass. `localDateString()` is this
+  // file's convention; `calendarPeriodBounds` reads a Date's *UTC* calendar
+  // fields, so it's handed the local date anchored at noon UTC. That keeps the
+  // non-native branch's period bounds and its `daysLeft` count in agreement at
+  // the UTC/local day boundary — an AU user (UTC+10/+11) opening the app before
+  // ~10am local is already on the next local day while UTC still shows the
+  // previous one, which otherwise skewed `daysLeft` and could mismatch the
+  // period label (#52).
+  const todayLocal = localDateString()
+  const todayLocalAtUtcNoon = new Date(`${todayLocal}T12:00:00Z`)
+
   for (const t of trackers) {
     const isNativePeriod =
       (displayPeriod === 'WEEKLY' && t.reset_frequency === 'WEEKLY') ||
@@ -551,16 +562,10 @@ export function getTrackersDisplayPeriodData(
       from = t.period_start ?? ''
       to = t.period_end ?? ''
     } else {
-      const bounds = calendarPeriodBounds(displayPeriod)
+      const bounds = calendarPeriodBounds(displayPeriod, 0, todayLocalAtUtcNoon)
       spent = getTrackerSpentInPeriod(t.id, bounds.from, bounds.to)
       budget = toPeriodCents(t.budget_amount, t.reset_frequency, displayPeriod)
-      // NOTE: the pre-extraction component used UTC `new Date().toISOString()`
-      // for "today" here, unlike this file's `localDateString()` convention.
-      // Kept as-is so the extraction changes no behaviour; worth reconciling.
-      daysLeft = Math.max(
-        0,
-        daysBetweenDateStr(new Date().toISOString().slice(0, 10), bounds.to)
-      )
+      daysLeft = Math.max(0, daysBetweenDateStr(todayLocal, bounds.to))
       from = bounds.from
       to = bounds.to
     }


### PR DESCRIPTION
Closes #52. Second attempt after #53 was closed unmerged — the one-line swap there wasn't enough.

## Problem
`getTrackersDisplayPeriodData`'s non-native branch computed `daysLeft` from **UTC** today (`new Date().toISOString().slice(0, 10)`), while the rest of `trackers.ts` uses `localDateString()`. #53 swapped that one expression for `localDateString()`, but `calendarPeriodBounds` still derives its bounds from UTC `now` internally. A local `daysLeft` against UTC-derived bounds/label then **disagree at the UTC/local day boundary**: for an AU user (UTC+10/+11) opening the app before ~10am local, UTC is still the previous calendar day, so the card could read e.g. "1 Mar – 31 Mar · 0 days left", or a label/`daysLeft` mismatch at month rollover. Pre-#53 both sides were UTC and merely one day stale, but consistent.

## Fix
Compute one local "today" once per pass and thread it through **both**:
- `calendarPeriodBounds(displayPeriod, 0, todayLocalAtUtcNoon)` — the local date anchored at noon UTC, so the function's `getUTC*` reads land on the local calendar day (the same noon-UTC idiom `dateStr.ts` uses internally).
- `daysBetweenDateStr(todayLocal, bounds.to)` — same string.

Bounds, `dateRangeLabel` and `daysLeft` are now derived from a single reference date.

Also updated the non-native YEARLY label test to compare against the local year (it now anchors local), which incidentally removes a latent New-Year's-Day flake.

## Test
`trackers.test.ts` +1: runs under `TZ=Australia/Sydney` at `2026-03-31T14:00:00Z` (01:00 local — an edge hour where UTC is still 31 Mar and local is already 1 Apr). Asserts `daysLeft === 30` and an April range label. Verified it **fails against both** the pre-#53 code (`daysLeft` 1) and the #53 one-liner (`daysLeft` 0), so it protects against a revert to either.

## Verification
- `npm run validate` — 0 errors (3 pre-existing warnings).
- Full unit suite: **540 passing**.

## Out of scope
`buildCalendarPeriodHistory` in `AnalyticsTrackersDetail.tsx` passes a raw `new Date()` to `calendarPeriodBounds` with the same latent UTC/local skew on its history rows/labels. Separate from #52; not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)