### PR TITLE
Anchor tracker-detail period history + pace on the local date, not UTC (#56)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Fixed
 
 - **Net Worth's projected balance undercounted recurring charges.** The "upcoming expense" figure on the Net Worth card only counted the first occurrence of a WEEKLY/FORTNIGHTLY reserved charge before payday, while Spendable's Reserved amount correctly summed every occurrence in the window — the two cards could disagree by the charge's amount times its occurrence count. `getProjectedNetWorth()` now shares Reserved's occurrence-counting logic. See `src/services/netWorth.ts`, `src/services/netWorth.test.ts` (new).
+- **Tracker day-counts and period history were counted from UTC, not your local date.** The "N days left" figure on tracker cards (Dashboard and Analytics overview) and the period-history rows and "today" marker on a tracker's detail page took "today" from UTC instead of the local calendar date used everywhere else — so for AU users (UTC+10/+11) opening the app before ~10am, a card could show one day too many and the detail page could treat the previous month/week as the current period. See `src/services/trackers.ts`, `src/pages/analytics/trackerPeriodHistory.ts` (extracted from `AnalyticsTrackersDetail.tsx` so it's unit-testable), and their tests.
 
 ## [0.8.1] - 2026-07-30
 

--- a/src/pages/analytics/AnalyticsTrackersDetail.tsx
+++ b/src/pages/analytics/AnalyticsTrackersDetail.tsx
@@ -13,7 +13,6 @@ import {
 import {
   getTracker,
   getTrackerPeriodHistory,
-  getTrackerSpentInPeriod,
   getTrackerTransactionTimeline,
   getTrackerTransactionsForTable,
   getTrackerTransactionsCount,
@@ -22,22 +21,17 @@ import {
   type TrackerResetFrequency,
   type TrackerPeriodHistoryRow,
 } from '@/services/trackers'
-import {
-  toPeriodCents,
-  type BudgetDisplayPeriod,
-} from '@/lib/monthlyEquivalent'
+import { type BudgetDisplayPeriod } from '@/lib/monthlyEquivalent'
 import { getCategories } from '@/services/categories'
 import {
   formatMoney,
   formatDate,
   formatShortDate,
   formatShortDateWithYear,
+  localDateString,
 } from '@/lib/format'
-import {
-  addDaysToDateStr,
-  calendarPeriodBounds,
-  daysBetweenDateStr,
-} from '@/lib/dateStr'
+import { addDaysToDateStr, daysBetweenDateStr } from '@/lib/dateStr'
+import { buildCalendarPeriodHistory } from './trackerPeriodHistory'
 import { TrackerHistoryChart } from '@/components/charts/TrackerHistoryChart'
 import { TrackerPaceChart } from '@/components/charts/TrackerPaceChart'
 import { useMediaQuery } from '@/hooks/useMediaQuery'
@@ -65,61 +59,6 @@ function displayPeriodEnd(isoDate: string): string {
   return addDaysToDateStr(isoDate, -1)
 }
 
-function buildCalendarPeriodHistory(
-  trackerId: number,
-  displayPeriod: BudgetDisplayPeriod,
-  periodsBack: number,
-  trackerBudget: number,
-  trackerFrequency: TrackerResetFrequency
-): TrackerPeriodHistoryRow[] {
-  const today = new Date()
-  const normalizedBudget = toPeriodCents(
-    trackerBudget,
-    trackerFrequency,
-    displayPeriod
-  )
-  const result: TrackerPeriodHistoryRow[] = []
-
-  for (let offset = -periodsBack + 1; offset <= 0; offset++) {
-    const { from, to } = calendarPeriodBounds(displayPeriod, offset, today)
-    let label: string
-
-    if (displayPeriod === 'WEEKLY') {
-      label =
-        offset === 0
-          ? 'This week'
-          : offset === -1
-            ? 'Last week'
-            : `${-offset} weeks ago`
-    } else if (displayPeriod === 'MONTHLY') {
-      label =
-        offset === 0
-          ? 'Current'
-          : offset === -1
-            ? 'Previous'
-            : `${-offset} months ago`
-    } else {
-      // YEARLY
-      label = offset === 0 ? 'Current' : from.slice(0, 4)
-    }
-
-    const spent = getTrackerSpentInPeriod(trackerId, from, to)
-    const remaining = Math.max(0, normalizedBudget - spent)
-    const progress = normalizedBudget > 0 ? (spent / normalizedBudget) * 100 : 0
-    result.push({
-      periodOffset: offset,
-      periodLabel: label,
-      periodStart: from,
-      periodEnd: to,
-      budget: normalizedBudget,
-      spent,
-      remaining,
-      progress,
-    })
-  }
-  return result
-}
-
 export function AnalyticsTrackersDetail() {
   const { trackerId } = useParams<{ trackerId: string }>()
   const [displayPeriod, setDisplayPeriod] =
@@ -133,7 +72,10 @@ export function AnalyticsTrackersDetail() {
   const isMobile = useMediaQuery(MOBILE_MEDIA_QUERY)
   const lastSyncCompletedAt = useStore(syncStore, (s) => s.lastSyncCompletedAt)
 
-  const today = new Date().toISOString().slice(0, 10)
+  // Local calendar date — feeds the pace math (`daysElapsed` / `daysLeft`) and
+  // the `today` marker on the pace chart. UTC here reads a day stale for
+  // UTC+10/+11 users in the early-morning-local window (#56).
+  const today = localDateString()
 
   const id = trackerId != null ? parseInt(trackerId, 10) : NaN
   const tracker = useMemo(

--- a/src/pages/analytics/trackerPeriodHistory.test.ts
+++ b/src/pages/analytics/trackerPeriodHistory.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('@/db', () => ({
+  getDb: () => null,
+  getAppSetting: () => null,
+  schedulePersist: () => {},
+}))
+
+const { buildCalendarPeriodHistory } = await import('./trackerPeriodHistory')
+const { toPeriodCents } = await import('@/lib/monthlyEquivalent')
+
+describe('buildCalendarPeriodHistory', () => {
+  it('returns one row per period, newest (offset 0) last, budget scaled to the display period', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-05-15T12:00:00Z'))
+    try {
+      const rows = buildCalendarPeriodHistory(1, 'MONTHLY', 3, 20000, 'WEEKLY')
+      expect(rows.map((r) => r.periodOffset)).toEqual([-2, -1, 0])
+      expect(rows.map((r) => r.periodLabel)).toEqual([
+        '2 months ago',
+        'Previous',
+        'Current',
+      ])
+      expect(rows[2].periodStart).toBe('2026-05-01')
+      expect(rows[2].periodEnd).toBe('2026-06-01')
+      expect(rows[2].budget).toBe(toPeriodCents(20000, 'WEEKLY', 'MONTHLY'))
+      // no DB in this suite → spend re-sums to 0
+      expect(rows[2].spent).toBe(0)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('anchors the current period on the local calendar date, not UTC (#56)', () => {
+    const originalTz = process.env.TZ
+    // UTC+11 in March (Australian daylight saving) — every Up Bank customer
+    // is on an AU offset.
+    process.env.TZ = 'Australia/Sydney'
+    vi.useFakeTimers()
+    // 2026-03-31 14:00 UTC == 2026-04-01 01:00 in Sydney: UTC is still on
+    // 31 March, the local calendar has already rolled into April.
+    vi.setSystemTime(new Date('2026-03-31T14:00:00Z'))
+    try {
+      const rows = buildCalendarPeriodHistory(1, 'MONTHLY', 2, 40000, 'MONTHLY')
+      const current = rows.find((r) => r.periodOffset === 0)!
+      const previous = rows.find((r) => r.periodOffset === -1)!
+      // Local "today" is 1 Apr, so April is "Current" — not March, which a
+      // raw UTC `new Date()` would still report at this instant.
+      expect(current.periodStart).toBe('2026-04-01')
+      expect(current.periodEnd).toBe('2026-05-01')
+      expect(previous.periodStart).toBe('2026-03-01')
+      expect(previous.periodEnd).toBe('2026-04-01')
+    } finally {
+      vi.useRealTimers()
+      process.env.TZ = originalTz
+    }
+  })
+})

--- a/src/pages/analytics/trackerPeriodHistory.ts
+++ b/src/pages/analytics/trackerPeriodHistory.ts
@@ -1,0 +1,80 @@
+import {
+  toPeriodCents,
+  type BudgetDisplayPeriod,
+} from '@/lib/monthlyEquivalent'
+import { calendarPeriodBounds } from '@/lib/dateStr'
+import { localDateString } from '@/lib/format'
+import {
+  getTrackerSpentInPeriod,
+  type TrackerResetFrequency,
+  type TrackerPeriodHistoryRow,
+} from '@/services/trackers'
+
+/**
+ * Period-history rows for a *non-native* display period on the tracker detail
+ * page: spend is re-summed over each calendar week / month / year and the
+ * budget is scaled to that period with `toPeriodCents`. `offset` runs from
+ * `-(periodsBack - 1)` … `0`, where `0` is the current period.
+ *
+ * "Today" is the **local** calendar date — the convention shared with
+ * `services/trackers` and the Spendable calculation. It is handed to
+ * `calendarPeriodBounds` as noon UTC because that helper reads a `Date`'s UTC
+ * calendar fields; a raw `new Date()` would put a UTC+10/+11 user (i.e. every
+ * Up Bank customer) opening the page before ~10am local into the previous
+ * calendar period as "Current", with every row's bounds shifted a day (#56,
+ * the same UTC/local class as #52).
+ */
+export function buildCalendarPeriodHistory(
+  trackerId: number,
+  displayPeriod: BudgetDisplayPeriod,
+  periodsBack: number,
+  trackerBudget: number,
+  trackerFrequency: TrackerResetFrequency
+): TrackerPeriodHistoryRow[] {
+  const today = new Date(`${localDateString()}T12:00:00Z`)
+  const normalizedBudget = toPeriodCents(
+    trackerBudget,
+    trackerFrequency,
+    displayPeriod
+  )
+  const result: TrackerPeriodHistoryRow[] = []
+
+  for (let offset = -periodsBack + 1; offset <= 0; offset++) {
+    const { from, to } = calendarPeriodBounds(displayPeriod, offset, today)
+    let label: string
+
+    if (displayPeriod === 'WEEKLY') {
+      label =
+        offset === 0
+          ? 'This week'
+          : offset === -1
+            ? 'Last week'
+            : `${-offset} weeks ago`
+    } else if (displayPeriod === 'MONTHLY') {
+      label =
+        offset === 0
+          ? 'Current'
+          : offset === -1
+            ? 'Previous'
+            : `${-offset} months ago`
+    } else {
+      // YEARLY
+      label = offset === 0 ? 'Current' : from.slice(0, 4)
+    }
+
+    const spent = getTrackerSpentInPeriod(trackerId, from, to)
+    const remaining = Math.max(0, normalizedBudget - spent)
+    const progress = normalizedBudget > 0 ? (spent / normalizedBudget) * 100 : 0
+    result.push({
+      periodOffset: offset,
+      periodLabel: label,
+      periodStart: from,
+      periodEnd: to,
+      budget: normalizedBudget,
+      spent,
+      remaining,
+      progress,
+    })
+  }
+  return result
+}


### PR DESCRIPTION
Closes #56. Same UTC-vs-local "today" class as #52 / PR #55, on the tracker **detail** page.

## Problem
`src/pages/analytics/AnalyticsTrackersDetail.tsx` derived "today" from UTC in two spots while the rest of the trackers domain uses `localDateString()`:

1. **`buildCalendarPeriodHistory`** passed a raw `new Date()` to `calendarPeriodBounds`, which reads a `Date`'s **UTC** calendar fields. For a UTC+10/+11 user (every Up Bank customer) opening the page before ~10am local, the current calendar month/week hasn't started in UTC yet — so the "Current" history row, and every row's `periodStart`/`periodEnd`, was a day/period behind.
2. **Component-level `today`** (`new Date().toISOString().slice(0, 10)`) fed the pace math (`daysElapsed` / `daysLeft`, so the "ahead/behind pace" call) and the `today={today}` marker on `TrackerPaceChart` — one day stale in the same early-morning-local window.

## Fix
- `buildCalendarPeriodHistory`: `new Date(`${localDateString()}T12:00:00Z`)` — the local calendar date anchored at noon UTC, the same idiom `dateStr.ts` uses internally, so `calendarPeriodBounds`' `getUTC*` reads land on the local day.
- Component `today`: `localDateString()`.

## Refactor
`buildCalendarPeriodHistory` is extracted verbatim (bar the `today` line) into a sibling **`trackerPeriodHistory.ts`** so it's unit-testable in the `node` suite — matching `importErrorClassification.ts` next to `ImportProfileModal.tsx` and the #49/#51 `getTrackersDisplayPeriodData` extraction. No behaviour change beyond the fix.

## Tests
`src/pages/analytics/trackerPeriodHistory.test.ts` (new, +2):
- baseline: one row per period, offset order, budget scaled with `toPeriodCents`.
- **#56 guard**: runs under `TZ=Australia/Sydney` at `2026-03-31T14:00:00Z` (01:00 local — UTC still 31 Mar, local already 1 Apr). Asserts April is "Current" with April bounds and March as "Previous". Verified it **fails** against the pre-fix raw-`new Date()` code (`periodStart` `2026-03-01`).

## Verification
- `npm run validate` — 0 errors (3 pre-existing warnings).
- Full unit suite: **541 passing** (43 files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)