### PR TITLE
Fix two date-arithmetic edge cases in the reports comparison engine (#23)

### DIFF
--- a/src/services/insights.test.ts
+++ b/src/services/insights.test.ts
@@ -84,6 +84,17 @@ describe('getYearComparisonPeriods', () => {
     expect(r.previous.from).toBe('2025-01-01')
     expect(r.previous.to).toBe('2025-04-15')
   })
+
+  it('clamps the prior-year YTD end to Feb 28 on a leap-year Feb 29', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date(2028, 1, 29)) // Feb 29, 2028 — a leap year
+    const r = getYearComparisonPeriods(2028)
+    expect(r.current.to).toBe('2028-02-29')
+    // setFullYear(2027) on a Feb-29 Date normalises to 2027-03-01, which would
+    // make the prior-year window a day longer than the current YTD. It must
+    // clamp to Feb 28 so both windows span the same elapsed days.
+    expect(r.previous.to).toBe('2027-02-28')
+  })
 })
 
 describe('getYearComparison periodNote', () => {
@@ -234,6 +245,82 @@ describe('getWeekComparison', () => {
     expectedPrevEnd.setDate(expectedPrevEnd.getDate() + 6)
     expectedPrevEnd.setHours(23, 59, 59, 999)
     const expectedPrevEndIso = expectedPrevEnd.toISOString()
+
+    const previousBoundCalls = bindCalls.filter(
+      (args) => args[0] === expectedPrevStartIso
+    )
+    expect(previousBoundCalls.length).toBeGreaterThan(0)
+    for (const args of previousBoundCalls) {
+      expect(args[1]).toBe(expectedPrevEndIso)
+    }
+  })
+})
+
+describe('elapsed-day maths across a DST transition', () => {
+  // Between two local midnights that straddle a spring-forward, real elapsed
+  // time is N*24h - 1h, so a flat `msDiff / 86_400_000` floor lands one day
+  // short. Africa/Cairo springs forward at 00:00 on Fri 2026-04-24 (a weekday,
+  // so the transition sits inside a Mon–today window); America/New_York springs
+  // forward at 02:00 on 2026-03-08.
+  const ORIGINAL_TZ = process.env.TZ
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    if (ORIGINAL_TZ === undefined) delete process.env.TZ
+    else process.env.TZ = ORIGINAL_TZ
+    vi.useRealTimers()
+  })
+
+  function mockEmptyDb() {
+    const stmt = {
+      bind: () => {},
+      step: () => false,
+      get: () => undefined,
+      free: () => {},
+    }
+    vi.mocked(db.getDb).mockReturnValue({ prepare: () => stmt } as never)
+  }
+
+  it('getMonthComparison counts full elapsed days when a spring-forward falls inside the month', () => {
+    process.env.TZ = 'America/New_York'
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date(2026, 2, 20, 12)) // Mar 20, 2026 — after the Mar 8 transition
+    mockEmptyDb()
+
+    const result = getMonthComparison('2026-03-01', '2026-03-31')
+    // 20 elapsed days (Mar 1–20) -> previous month capped to Feb 1–20.
+    // A flat 24h divide would floor to 19 and cap to Feb 1–19.
+    expect(result.periodNote).toBe('Mar 1–Mar 20 vs Feb 1–Feb 20')
+  })
+
+  it('getWeekComparison caps the previous week to the true elapsed-day count when a spring-forward falls inside the week', () => {
+    process.env.TZ = 'Africa/Cairo'
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date(2026, 3, 25, 12)) // Sat Apr 25, 2026 — day after the Apr 24 00:00 transition
+
+    const bindCalls: unknown[][] = []
+    const stmt = {
+      bind: (args: unknown[]) => bindCalls.push(args),
+      step: () => false,
+      get: () => undefined,
+      free: () => {},
+    }
+    vi.mocked(db.getDb).mockReturnValue({ prepare: () => stmt } as never)
+
+    getWeekComparison(0)
+
+    // Current week Mon Apr 20 – today Sat Apr 25 = 6 elapsed days, so the
+    // previous week (Mon Apr 13 –) is capped to 6 days -> ends Apr 18.
+    // A flat 24h divide floors elapsed to 5 and would cap to Apr 17.
+    const prevMonday = new Date(2026, 3, 13)
+    prevMonday.setHours(0, 0, 0, 0)
+    const expectedPrevStartIso = prevMonday.toISOString()
+    const cappedEnd = new Date(2026, 3, 18)
+    cappedEnd.setHours(23, 59, 59, 999)
+    const expectedPrevEndIso = cappedEnd.toISOString()
 
     const previousBoundCalls = bindCalls.filter(
       (args) => args[0] === expectedPrevStartIso

--- a/src/services/insights.ts
+++ b/src/services/insights.ts
@@ -26,6 +26,7 @@
 
 import { getDb } from '@/db'
 import { formatMoney, localDateStartUtc, localDateEndUtc } from '@/lib/format'
+import { daysBetweenDateStr } from '@/lib/dateStr'
 import {
   buildMonthSpendingSeries,
   type MonthSpendingSeries,
@@ -920,9 +921,10 @@ export function getMonthComparison(
 
   if (todayStr < currentTo) {
     // Month is in progress — cap previous period to the same elapsed-day count.
-    const fromMs = new Date(currentFrom + 'T00:00:00').getTime()
-    const todayMs = new Date(todayStr + 'T00:00:00').getTime()
-    const daysElapsed = Math.floor((todayMs - fromMs) / 86400000) + 1
+    // daysBetweenDateStr anchors both dates at noon UTC, so a DST transition
+    // inside the window can't floor the day count one short (a flat 86_400_000
+    // ms divide would).
+    const daysElapsed = daysBetweenDateStr(currentFrom, todayStr) + 1
 
     effectivePreviousTo = capPreviousPeriodEnd(prev.from, daysElapsed, prev.to)
 
@@ -971,12 +973,16 @@ export function getYearComparisonPeriods(year: number): {
     const day = now.getDate()
     const currentTo = `${y}-${pad(m)}-${pad(day)}`
 
-    const endPrev = new Date(now)
-    endPrev.setFullYear(endPrev.getFullYear() - 1)
-    const py = endPrev.getFullYear()
-    const pm = endPrev.getMonth() + 1
-    const pd = endPrev.getDate()
-    const previousTo = `${py}-${pad(pm)}-${pad(pd)}`
+    // Same month + day one year back. On Feb 29, the prior year has no Feb 29,
+    // so clamp to that month's last valid day (Feb 28) — letting JS Date
+    // normalise `setFullYear(y - 1)` would instead roll it to Mar 1 and make
+    // the prior-year YTD window a day longer than the current one.
+    const py = y - 1
+    const prevMonthLastDay = new Date(
+      Date.UTC(py, now.getMonth() + 1, 0)
+    ).getUTCDate()
+    const pd = Math.min(day, prevMonthLastDay)
+    const previousTo = `${py}-${pad(m)}-${pad(pd)}`
 
     return {
       current: { from: `${year}-01-01`, to: currentTo },
@@ -1171,11 +1177,10 @@ function getDaysElapsedInWeek(
   weekOffset: number
 ): number {
   if (weekOffset !== 0) return 7
-  const monday = new Date(week.start)
-  monday.setHours(0, 0, 0, 0)
-  const today = new Date(now)
-  today.setHours(0, 0, 0, 0)
-  const diff = Math.floor((today.getTime() - monday.getTime()) / 86400000)
+  // Whole calendar days from Monday to today. daysBetweenDateStr anchors both
+  // ends at noon UTC, so a DST transition inside the week can't floor this one
+  // short (a flat 86_400_000 ms divide would).
+  const diff = daysBetweenDateStr(week.startStr, toDateOnly(now))
   return Math.min(7, Math.max(1, diff + 1))
 }
 


### PR DESCRIPTION
Closes #23.

Both risks flagged in #23 were investigated, **confirmed**, and fixed.

## 1. DST elapsed-day off-by-one

`getMonthComparison` and `getDaysElapsedInWeek` computed elapsed days as `Math.floor(msDiff / 86400000)` — a flat 24h. Across a spring-forward, real elapsed time between two local midnights is `N×24h − 1h`, so the floor lands one day short, shifting the previous-period cap by a day.

- **`getMonthComparison`** — reachable by any in-month transition. E.g. `America/New_York`, current month March, today Mar 20 → `daysElapsed` = 19 instead of 20, capping the previous-month comparison window to Feb 1–19 instead of Feb 1–20.
- **`getDaysElapsedInWeek`** — only reachable when the transition falls on a weekday inside the Mon→today window. The AU/US Sunday-02:00 rule never lands inside it, but zones like `Africa/Cairo` (Fri 00:00) do. Hardened regardless, for consistency with the module's noon-UTC anchoring.

Both sites now use `daysBetweenDateStr` (`@/lib/dateStr`), the existing DST-safe date-diff helper (anchors each end at noon UTC).

## 2. Feb-29 leap-year roll

`getYearComparisonPeriods`'s current-year branch did `endPrev.setFullYear(y - 1)` on a `Date` at Feb 29; JS normalises the non-existent prior-year Feb 29 forward to Mar 1, making the prior-year YTD window a day longer than the current one. It now clamps the prior-year end to that month's last valid day (Feb 28).

## Tests

Three targeted tests, each verified to fail without the fix:
- month comparison across an `America/New_York` spring-forward
- week comparison across an `Africa/Cairo` (weekday) spring-forward
- `getYearComparisonPeriods(2028)` on Feb 29

Full suite green: 545 unit tests + `npm run validate`.

`docs/features/reports/OVERVIEW.md` updated locally to mark both resolved (docs/ is gitignored, not in this repo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)