### PR TITLE
Reports: give custom date ranges a period comparison (#24)

### DIFF
--- a/src/pages/analytics/AnalyticsReports.tsx
+++ b/src/pages/analytics/AnalyticsReports.tsx
@@ -13,6 +13,7 @@ import {
 } from 'react-bootstrap'
 import {
   getMonthComparison,
+  getCustomRangeComparison,
   getCategoryBreakdownForDateRange,
   getInsightsForDateRange,
   type MonthDelta,
@@ -440,6 +441,15 @@ export function AnalyticsReports() {
     () => comparisonMonthPairLabels(year, month),
     [year, month]
   )
+  // Labels for the comparison card / KPI deltas. Custom range has no calendar
+  // month name, so it names the two windows generically.
+  const comparisonLabels = isCustomRange
+    ? {
+        currentLabel: 'Selected range',
+        previousLabel: 'the preceding period',
+        vsPriorShort: 'prev. period',
+      }
+    : monthPairLabels
 
   // --- Store ---
   const lastSyncCompletedAt = useStore(syncStore, (s) => s.lastSyncCompletedAt)
@@ -447,11 +457,22 @@ export function AnalyticsReports() {
   const mode = resolveTheme(themeMode)
 
   // --- Data ---
-  const comparison = useMemo(
+  const monthComparison = useMemo(
     () => (!isCustomRange ? getMonthComparison(from, to) : null),
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [from, to, isCustomRange, lastSyncCompletedAt]
   )
+  const customComparison = useMemo(
+    () =>
+      isCustomRange && !isInvalidRange && !!dateFrom && !!dateTo
+        ? getCustomRangeComparison(dateFrom, dateTo)
+        : null,
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [isCustomRange, isInvalidRange, dateFrom, dateTo, lastSyncCompletedAt]
+  )
+  // The active comparison for whichever mode is showing — both are the same
+  // MonthComparisonData shape (see ADR-0007's per-period callers).
+  const comparison = isCustomRange ? customComparison : monthComparison
   const rangeInsights = useMemo(
     () => (isCustomRange ? getInsightsForDateRange(dateFrom, dateTo) : null),
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -810,7 +831,7 @@ export function AnalyticsReports() {
                   delta={
                     comparison?.hasPreviousData ? comparison.moneyIn : undefined
                   }
-                  vsPriorLabel={monthPairLabels.vsPriorShort}
+                  vsPriorLabel={comparisonLabels.vsPriorShort}
                 />
                 <KpiCell
                   label="Money out"
@@ -821,7 +842,7 @@ export function AnalyticsReports() {
                       ? comparison.moneyOut
                       : undefined
                   }
-                  vsPriorLabel={monthPairLabels.vsPriorShort}
+                  vsPriorLabel={comparisonLabels.vsPriorShort}
                   invert
                   detail={
                     chargesCount > 0
@@ -838,7 +859,7 @@ export function AnalyticsReports() {
                       ? netDelta
                       : undefined
                   }
-                  vsPriorLabel={monthPairLabels.vsPriorShort}
+                  vsPriorLabel={comparisonLabels.vsPriorShort}
                 />
                 {!isCustomRange && chargeGroups.length > 0 && (
                   <KpiCell
@@ -857,11 +878,11 @@ export function AnalyticsReports() {
           </Card>
 
           {/* ─── Block 1b: What changed ───────────────────────────────────────── */}
-          {!isCustomRange && comparison?.hasPreviousData && (
+          {comparison?.hasPreviousData && (
             <Card className="grid-margin">
               <Card.Header>
                 <Card.Title className="mb-0">
-                  What changed vs {monthPairLabels.previousLabel}
+                  What changed vs {comparisonLabels.previousLabel}
                 </Card.Title>
                 {comparison.periodNote && (
                   <Card.Text as="div" className="small text-muted mt-1">
@@ -872,8 +893,8 @@ export function AnalyticsReports() {
               <Card.Body>
                 <ComparisonVisual
                   comparison={comparison}
-                  currentLabel={monthPairLabels.currentLabel}
-                  priorLabel={monthPairLabels.previousLabel}
+                  currentLabel={comparisonLabels.currentLabel}
+                  priorLabel={comparisonLabels.previousLabel}
                 />
               </Card.Body>
             </Card>

--- a/src/services/insights.test.ts
+++ b/src/services/insights.test.ts
@@ -10,6 +10,7 @@ import {
   getWeekComparison,
   getYearComparison,
   getMonthComparison,
+  getCustomRangeComparison,
 } from './insights'
 import { localDateStartUtc, localDateEndUtc } from '@/lib/format'
 import * as db from '@/db'
@@ -176,6 +177,75 @@ describe('getMonthComparison', () => {
 
     const result = getMonthComparison('2026-04-01', '2026-04-30')
     expect(result.periodNote).toBeUndefined()
+  })
+})
+
+describe('getCustomRangeComparison', () => {
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.clearAllMocks()
+  })
+
+  /** Captures every `[startUtc, endUtc]` pair the comparison queries bind. */
+  function mockCapturingDb() {
+    const bindCalls: unknown[][] = []
+    const stmt = {
+      bind: (args: unknown[]) => bindCalls.push(args),
+      step: () => false,
+      get: () => undefined,
+      free: () => {},
+    }
+    vi.mocked(db.getDb).mockReturnValue({ prepare: () => stmt } as never)
+    return bindCalls
+  }
+
+  const boundTo = (from: string, to: string) => (args: unknown[]) =>
+    args[0] === localDateStartUtc(from) && args[1] === localDateEndUtc(to)
+
+  it('compares a fully-past range against the equal-length window immediately before it', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date(2026, 7, 1)) // Aug 1, 2026 — range is over
+    const bindCalls = mockCapturingDb()
+
+    const result = getCustomRangeComparison('2026-06-01', '2026-06-14')
+
+    // 14-day range -> previous window is May 18–31 (the 14 days before Jun 1).
+    expect(bindCalls.some(boundTo('2026-05-18', '2026-05-31'))).toBe(true)
+    expect(result.periodNote).toBeUndefined()
+  })
+
+  it('collapses a single-day range to the single preceding day', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date(2026, 7, 1))
+    const bindCalls = mockCapturingDb()
+
+    getCustomRangeComparison('2026-06-15', '2026-06-15')
+
+    expect(bindCalls.some(boundTo('2026-06-14', '2026-06-14'))).toBe(true)
+  })
+
+  it('caps the previous window to the elapsed-day count for a range that runs past today', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date(2026, 5, 10)) // Jun 10, 2026 — inside the range
+    const bindCalls = mockCapturingDb()
+
+    const result = getCustomRangeComparison('2026-06-01', '2026-06-30')
+
+    // 10 elapsed days (Jun 1–10) -> previous window capped to May 22–31.
+    expect(result.periodNote).toBe('Jun 1–Jun 10 vs May 22–May 31')
+    expect(bindCalls.some(boundTo('2026-05-22', '2026-05-31'))).toBe(true)
+  })
+
+  it('does not cap (or note) a range that lies entirely in the future', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date(2026, 5, 1)) // Jun 1, 2026 — range starts Jul 1
+    const bindCalls = mockCapturingDb()
+
+    const result = getCustomRangeComparison('2026-07-01', '2026-07-10')
+
+    expect(result.periodNote).toBeUndefined()
+    // Full 10-day previous window, Jun 21–30.
+    expect(bindCalls.some(boundTo('2026-06-21', '2026-06-30'))).toBe(true)
   })
 })
 

--- a/src/services/insights.ts
+++ b/src/services/insights.ts
@@ -26,7 +26,7 @@
 
 import { getDb } from '@/db'
 import { formatMoney, localDateStartUtc, localDateEndUtc } from '@/lib/format'
-import { daysBetweenDateStr } from '@/lib/dateStr'
+import { addDaysToDateStr, daysBetweenDateStr } from '@/lib/dateStr'
 import {
   buildMonthSpendingSeries,
   type MonthSpendingSeries,
@@ -698,8 +698,8 @@ function fmtDayMonth(dateStr: string): string {
   return `${MONTH_ABBR[monthIdx]} ${day}`
 }
 
-/** Labels for period-over-period narratives (vs last month/year/week). */
-export type NarrativePeriod = 'month' | 'year' | 'week'
+/** Labels for period-over-period narratives (vs last month/year/week/range). */
+export type NarrativePeriod = 'month' | 'year' | 'week' | 'custom'
 
 function narrativePriorLabel(
   p: NarrativePeriod,
@@ -713,6 +713,12 @@ function narrativePriorLabel(
       return yearNarrativePriorLabel(previousFrom)
     case 'week':
       return weekNarrativePriorLabel(previousFrom)
+    case 'custom': {
+      // The preceding equal-length window has no calendar name — describe it
+      // by its span instead ("the preceding 14 days").
+      const n = daysBetweenDateStr(previousFrom, currentFrom)
+      return `the preceding ${n} day${n === 1 ? '' : 's'}`
+    }
     default:
       return monthNarrativePriorLabel(previousFrom, currentFrom)
   }
@@ -1054,6 +1060,46 @@ export function getWeekComparison(weekOffset: number): MonthComparisonData {
     effectivePreviousEndIso,
     'week'
   )
+}
+
+/**
+ * KPI comparison for an arbitrary custom date range (the Reports page's
+ * custom-range mode). "Previous" is the equal-length window immediately
+ * preceding `from` — the fourth caller anticipated by ADR-0007.
+ *
+ * Both dates are local "YYYY-MM-DD". If the range runs past today it is only
+ * partially elapsed, so — mirroring getMonthComparison — the preceding window
+ * is capped to the elapsed-day count (from..today) and a periodNote spells the
+ * two windows out. A fully-past range compares against a full equal-length
+ * window with no note.
+ */
+export function getCustomRangeComparison(
+  from: string,
+  to: string
+): MonthComparisonData {
+  const todayStr = toDateOnly(new Date())
+
+  // Cap only when the range has started but not finished (today in [from, to)).
+  const isInProgress = todayStr >= from && todayStr < to
+  const effectiveTo = isInProgress ? todayStr : to
+
+  const lengthDays = daysBetweenDateStr(from, effectiveTo) + 1
+  const previousTo = addDaysToDateStr(from, -1)
+  const previousFrom = addDaysToDateStr(from, -lengthDays)
+
+  const result = getPeriodComparison(
+    from,
+    to,
+    previousFrom,
+    previousTo,
+    'custom'
+  )
+
+  const periodNote = isInProgress
+    ? `${fmtDayMonth(from)}–${fmtDayMonth(effectiveTo)} vs ${fmtDayMonth(previousFrom)}–${fmtDayMonth(previousTo)}`
+    : undefined
+
+  return { ...result, periodNote }
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #24.

Custom-range mode on the Reports page previously hard-set `comparison = null` — zero KPI deltas, no "What changed" card. This adds the fourth `getPeriodComparison` caller ADR-0007 anticipated.

## `getCustomRangeComparison(from, to)` (`src/services/insights.ts`)

- **"Previous"** = the equal-length window immediately preceding `from` (`previousTo = from − 1 day`, `previousFrom = from − lengthDays`).
- **In-progress range** (today in `[from, to)`): only partially elapsed, so — mirroring `getMonthComparison` — the preceding window is capped to the elapsed-day count (`from..today`) and a `periodNote` spells both windows out (`Jun 1–Jun 10 vs May 22–May 31`).
- **Fully-past range**: full equal-length preceding window, no note.
- **Entirely-future range** (today < from): no cap, no note.
- All date maths goes through the DST-safe `@/lib/dateStr` helpers.
- `NarrativePeriod` gains `'custom'`; the window has no calendar name so narratives read "…vs the preceding N days".

## `AnalyticsReports.tsx`

Custom-range mode now feeds this comparison into the same Financial Snapshot KPI deltas and "What changed" card that month mode uses. Window labels are generic in custom mode ("Selected range" / "the preceding period"). Month-only cards (Upcoming Charges, per-period tracker sub-bars) are untouched.

## Tests

4 cases for `getCustomRangeComparison`: fully-past window bounds, single-day range collapsing to the preceding day, past-today capping + `periodNote`, and an entirely-future range. Full suite: 549 → 553 unit tests, `npm run validate` + `npm run build` clean.

Docs (`docs/` is gitignored): `ADR-0007` caller list + `reports/OVERVIEW.md` "Custom-range gap" section to be updated to mark #24 resolved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)