### PR TITLE
Drop the dead transaction_user_data.user_category_override column (#27)

### DIFF
--- a/src/db/schema.migration.test.ts
+++ b/src/db/schema.migration.test.ts
@@ -159,7 +159,7 @@ describe('v36 migration: bank-statement-import removal', () => {
       `SELECT value FROM app_settings WHERE key = 'schema_version'`
     )
     expect(versionRow[0].values[0][0]).toBe(String(SCHEMA_VERSION))
-    expect(SCHEMA_VERSION).toBe(42)
+    expect(SCHEMA_VERSION).toBe(43)
 
     // The credit-card-import account is gone.
     const ccAccount = db.exec(`SELECT * FROM accounts WHERE id = 'cc-visa'`)
@@ -214,16 +214,14 @@ describe('v36 migration: bank-statement-import removal', () => {
       expect(exists.length).toBe(0)
     }
 
-    // The transfer-override column itself is dropped from transaction_user_data.
+    // The transfer-override column itself is dropped from transaction_user_data
+    // (as is user_category_override, later, by v43).
     const cols = db.exec(`PRAGMA table_info(transaction_user_data)`)
     const colNames = cols[0].values.map((r) => String(r[1]))
     expect(colNames).not.toContain('user_transfer_account_override')
+    expect(colNames).not.toContain('user_category_override')
     expect(colNames).toEqual(
-      expect.arrayContaining([
-        'transaction_id',
-        'user_notes',
-        'user_category_override',
-      ])
+      expect.arrayContaining(['transaction_id', 'user_notes'])
     )
 
     db.close()
@@ -702,18 +700,16 @@ describe('v41 migration: drop dead transaction_user_data.is_income column', () =
     const cols = db.exec(`PRAGMA table_info(transaction_user_data)`)
     const colNames = cols[0].values.map((r) => String(r[1]))
     expect(colNames).not.toContain('is_income')
+    // user_category_override is also gone by the time migrations finish (v43).
+    expect(colNames).not.toContain('user_category_override')
     expect(colNames).toEqual(
-      expect.arrayContaining([
-        'transaction_id',
-        'user_notes',
-        'user_category_override',
-      ])
+      expect.arrayContaining(['transaction_id', 'user_notes'])
     )
 
     const row = db.exec(
-      `SELECT transaction_id, user_notes, user_category_override FROM transaction_user_data`
+      `SELECT transaction_id, user_notes FROM transaction_user_data`
     )
-    expect(row[0].values[0]).toEqual(['tx-1', 'note here', 'groceries'])
+    expect(row[0].values[0]).toEqual(['tx-1', 'note here'])
 
     db.close()
   })
@@ -782,6 +778,70 @@ describe('v42 migration: drop dead accounts.monthly_deposit_target_cents column'
 
   it('is a no-op when the column is already gone, and is idempotent', () => {
     const db = buildLegacyV41Database()
+    runMigrations(db)
+    expect(() => runMigrations(db)).not.toThrow()
+    db.close()
+  })
+})
+
+/**
+ * Minimal v42-shaped fixture for the v43 migration, which drops the dead
+ * `transaction_user_data.user_category_override` column (#27 — displayed but
+ * never written by the app and never flowed through any category-keyed query).
+ * Carries the column plus a note-bearing row and an override-only row.
+ */
+function buildLegacyV42Database(): Database {
+  const db = new SQL.Database()
+  db.run(
+    `CREATE TABLE app_settings (key TEXT PRIMARY KEY, value TEXT NOT NULL)`
+  )
+  db.run(
+    `INSERT INTO app_settings (key, value) VALUES ('schema_version', '42')`
+  )
+  db.run(`
+    CREATE TABLE transaction_user_data (
+      transaction_id TEXT PRIMARY KEY,
+      user_notes TEXT,
+      user_category_override TEXT
+    )
+  `)
+  db.run(
+    `INSERT INTO transaction_user_data (transaction_id, user_notes, user_category_override)
+     VALUES ('tx-note', 'keep this note', 'groceries')`
+  )
+  db.run(
+    `INSERT INTO transaction_user_data (transaction_id, user_notes, user_category_override)
+     VALUES ('tx-override-only', NULL, 'rent')`
+  )
+  return db
+}
+
+describe('v43 migration: drop dead transaction_user_data.user_category_override column', () => {
+  it('drops the column, keeps note-bearing rows, and clears rows that only held an override', () => {
+    const db = buildLegacyV42Database()
+
+    runMigrations(db)
+
+    expect(readSetting(db, 'schema_version')).toBe(String(SCHEMA_VERSION))
+
+    const cols = db.exec(`PRAGMA table_info(transaction_user_data)`)
+    const colNames = cols[0].values.map((r) => String(r[1]))
+    expect(colNames).not.toContain('user_category_override')
+    expect(colNames).toEqual(
+      expect.arrayContaining(['transaction_id', 'user_notes'])
+    )
+
+    // The note row survives with its note intact.
+    const kept = db.exec(
+      `SELECT transaction_id, user_notes FROM transaction_user_data`
+    )
+    expect(kept[0].values).toEqual([['tx-note', 'keep this note']])
+
+    db.close()
+  })
+
+  it('is a no-op when the column is already gone, and is idempotent', () => {
+    const db = buildLegacyV42Database()
     runMigrations(db)
     expect(() => runMigrations(db)).not.toThrow()
     db.close()

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -5,7 +5,7 @@
 
 import type { Database } from 'sql.js'
 
-const SCHEMA_VERSION = 42
+const SCHEMA_VERSION = 43
 
 function tableExists(database: Database, name: string): boolean {
   const stmt = database.prepare(
@@ -142,7 +142,6 @@ const DDL_STATEMENTS = [
   `CREATE TABLE IF NOT EXISTS transaction_user_data (
     transaction_id TEXT PRIMARY KEY,
     user_notes TEXT,
-    user_category_override TEXT,
     FOREIGN KEY (transaction_id) REFERENCES transactions(id)
   )`,
   `CREATE TABLE IF NOT EXISTS future_items (
@@ -1145,6 +1144,29 @@ export function runMigrations(database: Database): void {
     database.run(
       `INSERT OR REPLACE INTO app_settings (key, value) VALUES ('schema_version', ?)`,
       ['42']
+    )
+  }
+
+  // #27 — transaction_user_data.user_category_override was a local re-categorise
+  // slot, but nothing in src/ ever wrote it (no UI), only demo seed data and a
+  // now-removed "clear on Up PATCH" line. It never flowed through filtering or
+  // category analytics. The real recategorise path is a PATCH to Up
+  // (updateTransactionCategoryLocal). Drop the column.
+  if (version < 43) {
+    const tudCols = database.exec(`PRAGMA table_info(transaction_user_data)`)
+    const tudHasOverride = (tudCols[0]?.values ?? []).some(
+      (r) => String(r[1]) === 'user_category_override'
+    )
+    if (tudHasOverride) {
+      database.run(
+        `ALTER TABLE transaction_user_data DROP COLUMN user_category_override`
+      )
+      // A row that only held an override (no note) is now empty noise — clear it.
+      database.run(`DELETE FROM transaction_user_data WHERE user_notes IS NULL`)
+    }
+    database.run(
+      `INSERT OR REPLACE INTO app_settings (key, value) VALUES ('schema_version', ?)`,
+      ['43']
     )
   }
 }

--- a/src/db/seedDemoData.ts
+++ b/src/db/seedDemoData.ts
@@ -816,48 +816,42 @@ export function seedDemoData(): void {
     ]
   )
 
-  // Transaction user data: notes and category overrides showcasing both features.
+  // Transaction user data: local notes on a handful of transactions.
   // demo-tx-0  = Woolworths (today)
   // demo-tx-5  = Uber Eats (5 days ago) — dinner note
   // demo-tx-7  = McDonald's (7 days ago)
   // demo-tx-10 = Caltex (10 days ago) — work expense note
-  // demo-tx-15 = Kmart (15 days ago) — category overridden to Groceries
   // demo-tx-22 = Starbucks (22 days ago) — coffee note
   // demo-income-0-0 = Salary credit — labelled for clarity
   run(
-    `INSERT OR REPLACE INTO transaction_user_data (transaction_id, user_notes, user_category_override)
-     VALUES (?, ?, ?)`,
-    ['demo-tx-0', 'Weekly grocery run', null]
+    `INSERT OR REPLACE INTO transaction_user_data (transaction_id, user_notes)
+     VALUES (?, ?)`,
+    ['demo-tx-0', 'Weekly grocery run']
   )
   run(
-    `INSERT OR REPLACE INTO transaction_user_data (transaction_id, user_notes, user_category_override)
-     VALUES (?, ?, ?)`,
-    ['demo-tx-5', 'Birthday dinner with Sarah', null]
+    `INSERT OR REPLACE INTO transaction_user_data (transaction_id, user_notes)
+     VALUES (?, ?)`,
+    ['demo-tx-5', 'Birthday dinner with Sarah']
   )
   run(
-    `INSERT OR REPLACE INTO transaction_user_data (transaction_id, user_notes, user_category_override)
-     VALUES (?, ?, ?)`,
-    ['demo-tx-7', 'Quick lunch on the go', null]
+    `INSERT OR REPLACE INTO transaction_user_data (transaction_id, user_notes)
+     VALUES (?, ?)`,
+    ['demo-tx-7', 'Quick lunch on the go']
   )
   run(
-    `INSERT OR REPLACE INTO transaction_user_data (transaction_id, user_notes, user_category_override)
-     VALUES (?, ?, ?)`,
-    ['demo-tx-10', 'Work trip — reimbursable', null]
+    `INSERT OR REPLACE INTO transaction_user_data (transaction_id, user_notes)
+     VALUES (?, ?)`,
+    ['demo-tx-10', 'Work trip — reimbursable']
   )
   run(
-    `INSERT OR REPLACE INTO transaction_user_data (transaction_id, user_notes, user_category_override)
-     VALUES (?, ?, ?)`,
-    ['demo-tx-15', null, catGroceries]
+    `INSERT OR REPLACE INTO transaction_user_data (transaction_id, user_notes)
+     VALUES (?, ?)`,
+    ['demo-tx-22', 'Morning coffee before the meeting']
   )
   run(
-    `INSERT OR REPLACE INTO transaction_user_data (transaction_id, user_notes, user_category_override)
-     VALUES (?, ?, ?)`,
-    ['demo-tx-22', 'Morning coffee before the meeting', null]
-  )
-  run(
-    `INSERT OR REPLACE INTO transaction_user_data (transaction_id, user_notes, user_category_override)
-     VALUES (?, ?, ?)`,
-    ['demo-income-0-0', 'Monthly salary', null]
+    `INSERT OR REPLACE INTO transaction_user_data (transaction_id, user_notes)
+     VALUES (?, ?)`,
+    ['demo-income-0-0', 'Monthly salary']
   )
 
   // Tags: 3 demo tags attached to representative transactions.

--- a/src/pages/Transactions.tsx
+++ b/src/pages/Transactions.tsx
@@ -23,7 +23,6 @@ import {
   type TransactionRow,
 } from '@/services/transactions'
 import { getCategories } from '@/services/categories'
-import { getTransactionUserDataMap } from '@/services/transactionUserData'
 import { updateTransactionCategoryLocal } from '@/services/transactions'
 import {
   getAllTags,
@@ -200,11 +199,6 @@ export function Transactions() {
     [parentIdsByDate]
   )
 
-  const userDataMap = useMemo(
-    () => getTransactionUserDataMap(parentIdsByDate),
-    [parentIdsByDate]
-  )
-
   const [editTxId, setEditTxId] = useState<string | null>(null)
   const editTxRow = useMemo(() => {
     if (!editTxId) return null
@@ -221,15 +215,7 @@ export function Transactions() {
     [editTxId, lastSyncCompletedAt]
   )
 
-  const editEffectiveCategory = useMemo(() => {
-    if (!editTxRow) return null
-    const savedOverride = userDataMap[editTxRow.id]?.user_category_override
-    if (savedOverride)
-      return (
-        categories.find((c) => c.id === savedOverride)?.name ?? savedOverride
-      )
-    return editTxRow.category_name
-  }, [editTxRow, userDataMap, categories])
+  const editCategoryName = editTxRow?.category_name ?? null
 
   const [categoryUpdating, setCategoryUpdating] = useState(false)
   const [categoryError, setCategoryError] = useState<string | null>(null)
@@ -904,15 +890,7 @@ export function Transactions() {
                         </div>
                         <div className="small text-muted">
                           {displayDate}
-                          {(() => {
-                            const ud = userDataMap[row.id]
-                            const overrideCat = ud?.user_category_override
-                            const effective = overrideCat
-                              ? (categories.find((c) => c.id === overrideCat)
-                                  ?.name ?? overrideCat)
-                              : row.category_name
-                            return effective ? ` · ${effective}` : ''
-                          })()}
+                          {row.category_name ? ` · ${row.category_name}` : ''}
                         </div>
                         <span
                           className={`badge mt-1 ${
@@ -1011,19 +989,7 @@ export function Transactions() {
                           <td>
                             {row.description || row.raw_text || 'Unknown'}
                           </td>
-                          <td>
-                            {(() => {
-                              const ud = userDataMap[row.id]
-                              const overrideCat = ud?.user_category_override
-                              if (overrideCat) {
-                                return (
-                                  categories.find((c) => c.id === overrideCat)
-                                    ?.name ?? overrideCat
-                                )
-                              }
-                              return row.category_name ?? ''
-                            })()}
-                          </td>
+                          <td>{row.category_name ?? ''}</td>
                           <td
                             className={`text-end ${isDebit ? '' : 'text-success'}`}
                           >
@@ -1159,10 +1125,10 @@ export function Transactions() {
                       )}
                     </dd>
                   </>
-                ) : editEffectiveCategory ? (
+                ) : editCategoryName ? (
                   <>
                     <dt className="col-sm-4 text-muted">Category</dt>
-                    <dd className="col-sm-8">{editEffectiveCategory}</dd>
+                    <dd className="col-sm-8">{editCategoryName}</dd>
                   </>
                 ) : null}
 

--- a/src/services/transactionUserData.test.ts
+++ b/src/services/transactionUserData.test.ts
@@ -3,7 +3,6 @@ import initSqlJs, { type Database, type SqlJsStatic } from 'sql.js'
 import {
   getTransactionUserData,
   setTransactionUserNote,
-  setTransactionUserCategoryOverride,
 } from './transactionUserData'
 
 vi.mock('@/db', () => ({
@@ -12,12 +11,11 @@ vi.mock('@/db', () => ({
 }))
 
 /**
- * #6 — real-DB coverage for the setters, whose four-way branch
- * (clear-one-keep-sibling / delete-when-both-empty / update / insert) is now
- * shared through the private `upsertUserDataField` helper. These assert both
- * exports still behave identically after the extraction.
+ * Real-DB coverage for `setTransactionUserNote`, the only user-owned field on
+ * `transaction_user_data` after #27 dropped `user_category_override`. The row is
+ * a pure overlay: it exists only while it carries a note.
  */
-describe('transactionUserData setters', () => {
+describe('setTransactionUserNote', () => {
   let SQL: SqlJsStatic
   let realDb: Database
 
@@ -32,143 +30,57 @@ describe('transactionUserData setters', () => {
     vi.mocked(db.schedulePersist).mockImplementation(() => {})
   })
 
-  function rawRow(transactionId: string): {
-    user_notes: string | null
-    user_category_override: string | null
-  } | null {
+  function rawNote(transactionId: string): string | null | undefined {
     const stmt = realDb.prepare(
-      `SELECT user_notes, user_category_override FROM transaction_user_data WHERE transaction_id = ?`
+      `SELECT user_notes FROM transaction_user_data WHERE transaction_id = ?`
     )
     stmt.bind([transactionId])
     if (!stmt.step()) {
       stmt.free()
-      return null
+      return undefined // no row
     }
-    const r = stmt.get() as [string | null, string | null]
+    const r = stmt.get() as [string | null]
     stmt.free()
-    return { user_notes: r[0], user_category_override: r[1] }
+    return r[0]
   }
-
-  // ── setTransactionUserNote ─────────────────────────────────────────────
 
   it('inserts a row when setting a note on an untouched transaction', () => {
     setTransactionUserNote('tx-1', 'remember this')
-    expect(rawRow('tx-1')).toEqual({
+    expect(getTransactionUserData('tx-1')).toEqual({
+      transaction_id: 'tx-1',
       user_notes: 'remember this',
-      user_category_override: null,
     })
   })
 
   it('trims the note and treats whitespace-only as a clear', () => {
     setTransactionUserNote('tx-1', '  padded  ')
-    expect(rawRow('tx-1')?.user_notes).toBe('padded')
+    expect(rawNote('tx-1')).toBe('padded')
 
     setTransactionUserNote('tx-1', '   ')
-    expect(rawRow('tx-1')).toBeNull()
+    expect(rawNote('tx-1')).toBeUndefined()
   })
 
   it('updates an existing row when the note changes', () => {
     setTransactionUserNote('tx-1', 'first')
     setTransactionUserNote('tx-1', 'second')
-    expect(rawRow('tx-1')).toEqual({
-      user_notes: 'second',
-      user_category_override: null,
-    })
+    expect(rawNote('tx-1')).toBe('second')
   })
 
-  it('clearing the note keeps the row when a category override is still set', () => {
-    setTransactionUserCategoryOverride('tx-1', 'cat-groceries')
+  it('clearing the note deletes the row', () => {
     setTransactionUserNote('tx-1', 'temp note')
     setTransactionUserNote('tx-1', null)
-    expect(rawRow('tx-1')).toEqual({
-      user_notes: null,
-      user_category_override: 'cat-groceries',
-    })
-  })
-
-  it('clearing the note deletes the row when nothing else is set', () => {
-    setTransactionUserNote('tx-1', 'temp note')
-    setTransactionUserNote('tx-1', null)
-    expect(rawRow('tx-1')).toBeNull()
+    expect(rawNote('tx-1')).toBeUndefined()
   })
 
   it('clearing the note on an untouched transaction is a no-op', () => {
     setTransactionUserNote('tx-1', null)
-    expect(rawRow('tx-1')).toBeNull()
-  })
-
-  // ── setTransactionUserCategoryOverride ────────────────────────────────
-
-  it('inserts a row when setting a category override on an untouched transaction', () => {
-    setTransactionUserCategoryOverride('tx-2', 'cat-rent')
-    expect(rawRow('tx-2')).toEqual({
-      user_notes: null,
-      user_category_override: 'cat-rent',
-    })
-  })
-
-  it('does not trim the category id', () => {
-    setTransactionUserCategoryOverride('tx-2', ' cat-with-space ')
-    expect(rawRow('tx-2')?.user_category_override).toBe(' cat-with-space ')
-  })
-
-  it('updates an existing row when the category override changes', () => {
-    setTransactionUserCategoryOverride('tx-2', 'cat-a')
-    setTransactionUserCategoryOverride('tx-2', 'cat-b')
-    expect(rawRow('tx-2')).toEqual({
-      user_notes: null,
-      user_category_override: 'cat-b',
-    })
-  })
-
-  it('clearing the category override keeps the row when a note is still set', () => {
-    setTransactionUserNote('tx-2', 'keep me')
-    setTransactionUserCategoryOverride('tx-2', 'cat-temp')
-    setTransactionUserCategoryOverride('tx-2', '')
-    expect(rawRow('tx-2')).toEqual({
-      user_notes: 'keep me',
-      user_category_override: null,
-    })
-  })
-
-  it('clearing the category override deletes the row when nothing else is set', () => {
-    setTransactionUserCategoryOverride('tx-2', 'cat-temp')
-    setTransactionUserCategoryOverride('tx-2', null)
-    expect(rawRow('tx-2')).toBeNull()
-  })
-
-  it('treats null and empty-string category ids identically as a clear', () => {
-    setTransactionUserCategoryOverride('tx-a', 'x')
-    setTransactionUserCategoryOverride('tx-a', null)
-    setTransactionUserCategoryOverride('tx-b', 'x')
-    setTransactionUserCategoryOverride('tx-b', '')
-    expect(rawRow('tx-a')).toBeNull()
-    expect(rawRow('tx-b')).toBeNull()
-  })
-
-  // ── both fields together ─────────────────────────────────────────────
-
-  it('keeps note and category override independent on one row', () => {
-    setTransactionUserNote('tx-3', 'a note')
-    setTransactionUserCategoryOverride('tx-3', 'cat-x')
-    expect(getTransactionUserData('tx-3')).toEqual({
-      transaction_id: 'tx-3',
-      user_notes: 'a note',
-      user_category_override: 'cat-x',
-    })
-
-    setTransactionUserNote('tx-3', null)
-    setTransactionUserCategoryOverride('tx-3', null)
-    expect(rawRow('tx-3')).toBeNull()
+    expect(rawNote('tx-1')).toBeUndefined()
   })
 
   it('throws when the database is not ready', async () => {
     const db = await import('@/db')
     vi.mocked(db.getDb).mockReturnValue(null as never)
     expect(() => setTransactionUserNote('tx-1', 'x')).toThrow(
-      'Database not ready'
-    )
-    expect(() => setTransactionUserCategoryOverride('tx-1', 'x')).toThrow(
       'Database not ready'
     )
   })

--- a/src/services/transactionUserData.ts
+++ b/src/services/transactionUserData.ts
@@ -1,7 +1,7 @@
 /**
- * Local-only user data for transactions: notes, category override, and
- * transfer-account override. Sync does not touch this; upstream category is
- * preserved in transactions table.
+ * Local-only user notes for transactions. Sync does not touch this table — the
+ * upstream `transactions` row always mirrors Up Bank exactly
+ * (see docs/adr/0008-transaction-user-data-is-a-separate-overlay.md).
  */
 
 import { getDb, schedulePersist } from '@/db'
@@ -9,7 +9,6 @@ import { getDb, schedulePersist } from '@/db'
 export interface TransactionUserRow {
   transaction_id: string
   user_notes: string | null
-  user_category_override: string | null
 }
 
 export function getTransactionUserData(
@@ -18,7 +17,7 @@ export function getTransactionUserData(
   const db = getDb()
   if (!db) return null
   const stmt = db.prepare(
-    `SELECT transaction_id, user_notes, user_category_override
+    `SELECT transaction_id, user_notes
      FROM transaction_user_data WHERE transaction_id = ?`
   )
   stmt.bind([transactionId])
@@ -26,12 +25,11 @@ export function getTransactionUserData(
     stmt.free()
     return null
   }
-  const row = stmt.get() as [string, string | null, string | null]
+  const row = stmt.get() as [string, string | null]
   stmt.free()
   return {
     transaction_id: row[0],
     user_notes: row[1],
-    user_category_override: row[2],
   }
 }
 
@@ -44,95 +42,52 @@ export function getTransactionUserDataMap(
   if (!db || transactionIds.length === 0) return out
   const placeholders = transactionIds.map(() => '?').join(',')
   const stmt = db.prepare(
-    `SELECT transaction_id, user_notes, user_category_override
+    `SELECT transaction_id, user_notes
      FROM transaction_user_data WHERE transaction_id IN (${placeholders})`
   )
   stmt.bind(transactionIds)
   while (stmt.step()) {
-    const row = stmt.get() as [string, string | null, string | null]
+    const row = stmt.get() as [string, string | null]
     out[row[0]] = {
       transaction_id: row[0],
       user_notes: row[1],
-      user_category_override: row[2],
     }
   }
   stmt.free()
   return out
 }
 
-/** The two nullable user-owned columns on transaction_user_data. */
-type UserDataField = 'user_notes' | 'user_category_override'
-
-const SIBLING_FIELD: Record<UserDataField, UserDataField> = {
-  user_notes: 'user_category_override',
-  user_category_override: 'user_notes',
-}
-
 /**
- * Set (or clear) one user-owned field on a transaction's row, keeping the row
- * a pure overlay: a `null` value clears the field, and the row is deleted once
- * both fields are empty so an untouched transaction has no row at all.
- * `value` must already be normalised by the caller (trimmed, `''` → `null`).
- * Field names come from the `UserDataField` union, never caller input, so the
- * interpolation into the SQL is safe.
+ * Set (or clear) a transaction's local note, keeping the row a pure overlay:
+ * an empty/`null` value deletes the row, so an untouched transaction has no row
+ * at all. `user_notes` is the only user-owned column on the table.
  */
-function upsertUserDataField(
-  transactionId: string,
-  field: UserDataField,
-  value: string | null
-): void {
-  const db = getDb()
-  if (!db) throw new Error('Database not ready')
-  const existing = getTransactionUserData(transactionId)
-
-  if (value === null) {
-    if (existing?.[SIBLING_FIELD[field]]) {
-      db.run(
-        `UPDATE transaction_user_data SET ${field} = NULL WHERE transaction_id = ?`,
-        [transactionId]
-      )
-    } else if (existing) {
-      db.run(`DELETE FROM transaction_user_data WHERE transaction_id = ?`, [
-        transactionId,
-      ])
-    }
-  } else if (existing) {
-    db.run(
-      `UPDATE transaction_user_data SET ${field} = ? WHERE transaction_id = ?`,
-      [value, transactionId]
-    )
-  } else {
-    db.run(
-      `INSERT INTO transaction_user_data (transaction_id, user_notes, user_category_override) VALUES (?, ?, ?)`,
-      [
-        transactionId,
-        field === 'user_notes' ? value : null,
-        field === 'user_category_override' ? value : null,
-      ]
-    )
-  }
-  schedulePersist()
-}
-
 export function setTransactionUserNote(
   transactionId: string,
   userNotes: string | null
 ): void {
+  const db = getDb()
+  if (!db) throw new Error('Database not ready')
   const trimmed = userNotes?.trim() ?? ''
-  upsertUserDataField(
-    transactionId,
-    'user_notes',
-    trimmed === '' ? null : trimmed
-  )
-}
+  const value = trimmed === '' ? null : trimmed
+  const exists = getTransactionUserData(transactionId) !== null
 
-export function setTransactionUserCategoryOverride(
-  transactionId: string,
-  categoryId: string | null
-): void {
-  upsertUserDataField(
-    transactionId,
-    'user_category_override',
-    categoryId === null || categoryId === '' ? null : categoryId
-  )
+  if (value === null) {
+    if (exists) {
+      db.run(`DELETE FROM transaction_user_data WHERE transaction_id = ?`, [
+        transactionId,
+      ])
+    }
+  } else if (exists) {
+    db.run(
+      `UPDATE transaction_user_data SET user_notes = ? WHERE transaction_id = ?`,
+      [value, transactionId]
+    )
+  } else {
+    db.run(
+      `INSERT INTO transaction_user_data (transaction_id, user_notes) VALUES (?, ?)`,
+      [transactionId, value]
+    )
+  }
+  schedulePersist()
 }

--- a/src/services/transactions.ts
+++ b/src/services/transactions.ts
@@ -38,8 +38,8 @@ export interface TransactionRow {
 }
 
 /**
- * Write a category change directly to the transaction row and clear any
- * local override. Called immediately after a successful PATCH to Up Bank.
+ * Write a category change directly to the transaction row. Called immediately
+ * after a successful PATCH to Up Bank.
  */
 export function updateTransactionCategoryLocal(
   transactionId: string,
@@ -50,10 +50,6 @@ export function updateTransactionCategoryLocal(
   db.run(
     `UPDATE transactions SET category_id = ?, parent_category_id = NULL WHERE id = ?`,
     [categoryId, transactionId]
-  )
-  db.run(
-    `UPDATE transaction_user_data SET user_category_override = NULL WHERE transaction_id = ?`,
-    [transactionId]
   )
   schedulePersist()
 }


### PR DESCRIPTION
Closes #27.

## The decision

#27 asked: should `user_category_override` take precedence wherever `category_id` is read (filtering, breakdowns, tracker attribution), or is it deliberately cosmetic?

Investigation changed the framing: **`setTransactionUserCategoryOverride` has no production caller.** Nothing in the app writes the column — the only writers were `seedDemoData` (a "Kmart → Groceries" demo row) and a line in `updateTransactionCategoryLocal` that *cleared* it after a real Up PATCH. `Transactions.tsx` only read it to render an "effective category" label; there is no "recategorise locally without touching Up" control anywhere. The real recategorise path (PATCH to Up → `updateTransactionCategoryLocal` writes `transactions.category_id`) is unaffected.

Threading `COALESCE(ud.user_category_override, t.category_id)` through ~10 category-keyed queries would also mean *building the missing write UI* for a feature with no demand signal. Decision (with Okky): **remove it** — consistent with `is_subscription` (#21), `is_income` (#26), `monthly_deposit_target_cents` (#28), and the earlier `user_transfer_account_override` removal.

## Changes

- **schema v43** — `ALTER TABLE transaction_user_data DROP COLUMN user_category_override`, then delete any row the drop left noteless (the overlay invariant: a row exists only while it carries a note). Base DDL updated.
- **`transactionUserData.ts`** — column gone from `TransactionUserRow` and both reads; `setTransactionUserCategoryOverride` deleted; the now-single-field `upsertUserDataField` helper collapsed back into `setTransactionUserNote`.
- **`transactions.ts`** — `updateTransactionCategoryLocal` no longer clears an override.
- **`Transactions.tsx`** — category display reads `category_name` directly; the orphaned `userDataMap` memo + its import removed.
- **`seedDemoData.ts`** — overlay rows are notes-only; the override-only demo row dropped.
- **Tests** — new v43 migration coverage (drop + noteless-row cleanup + idempotent); `transactionUserData.test.ts` reduced to the notes setter; v36/v41 migration assertions updated for the now-absent column. Full suite green, `npm run validate` + `npm run build` clean.

Docs (`docs/` is gitignored): ADR-0008 consequence line, `transactions/OVERVIEW.md`, and `DATABASE.md` to be updated to drop the override.

🤖 Generated with [Claude Code](https://claude.com/claude-code)