### PR TITLE
Savers: frame "ahead of pace" as a concrete win (#30)

### DIFF
--- a/src/pages/analytics/AnalyticsSavers.tsx
+++ b/src/pages/analytics/AnalyticsSavers.tsx
@@ -22,8 +22,6 @@ import {
   removeSaverGoal,
   reconcileSaverGoalAchievement,
   sumAccountBalancesCents,
-  type SaverBalanceSnapshot,
-  type SaverMonthlyFlowPoint,
 } from '@/services/accounts'
 import { getMonthlyInsights } from '@/services/insights'
 import type { MonthDelta } from '@/services/insights'
@@ -36,92 +34,7 @@ import { buildDeltaTooltip } from '@/components/atAGlance/deltaTooltip'
 import { previousCalendarMonth, monthNameLong } from '@/lib/monthLabels'
 import { getSaverOrder, setSaverOrder } from '@/lib/saverOrder'
 import { HelpPopover } from '@/components/HelpPopover'
-
-// Reconstruct end-of-month balances from flow data working backwards from current balance.
-// Both charts then share the same source and time window.
-const MONTH_MAP: Record<string, string> = {
-  Jan: '01',
-  Feb: '02',
-  Mar: '03',
-  Apr: '04',
-  May: '05',
-  Jun: '06',
-  Jul: '07',
-  Aug: '08',
-  Sep: '09',
-  Oct: '10',
-  Nov: '11',
-  Dec: '12',
-}
-
-function deriveMonthlyBalances(
-  flow: SaverMonthlyFlowPoint[],
-  saverId: string,
-  currentBalance: number
-): SaverBalanceSnapshot[] {
-  const result: SaverBalanceSnapshot[] = []
-  let b = currentBalance
-  for (let i = flow.length - 1; i >= 0; i--) {
-    const p = flow[i]
-    // "Jun '26" → "2026-06-01"
-    const [mon, yr] = p.monthLabel.split(' ')
-    const date = `20${yr.slice(1)}-${MONTH_MAP[mon]}-01`
-    result.unshift({
-      saver_id: saverId,
-      snapshot_date: date,
-      balance_cents: Math.max(0, b),
-    })
-    // balance at end of previous month = balance at end of this month + this month's flow
-    b += p.flowCents
-  }
-  return result
-}
-
-interface ProjectionResult {
-  onTrack: boolean
-  lastMonthCents: number
-  projectedBalanceCents: number
-  monthsRemaining: number
-  requiredMonthlyCents: number
-}
-
-function computeProjection(
-  currentBalanceCents: number,
-  goalCents: number,
-  monthlyFlow: SaverMonthlyFlowPoint[],
-  goalDate: string
-): ProjectionResult {
-  // Use the most recent complete month as the projected rate — matches Up Bank's
-  // payday-split behaviour where each month's contribution is consistent and
-  // the latest month is the most representative of the ongoing rate.
-  const complete = monthlyFlow.slice(0, -1)
-  const lastMonth = complete[complete.length - 1]
-  // flowCents is negative for savings; negate to get positive = monthly saving rate
-  const lastMonthCents = lastMonth ? -lastMonth.flowCents : 0
-
-  const today = new Date()
-  const target = new Date(goalDate)
-  const monthsRemaining = Math.max(
-    0,
-    (target.getFullYear() - today.getFullYear()) * 12 +
-      (target.getMonth() - today.getMonth())
-  )
-
-  const projectedBalanceCents =
-    currentBalanceCents + lastMonthCents * monthsRemaining
-  const requiredMonthlyCents =
-    monthsRemaining > 0
-      ? (goalCents - currentBalanceCents) / monthsRemaining
-      : Infinity
-
-  return {
-    onTrack: projectedBalanceCents >= goalCents,
-    lastMonthCents,
-    projectedBalanceCents,
-    monthsRemaining,
-    requiredMonthlyCents,
-  }
-}
+import { deriveMonthlyBalances, computeProjection } from './saverProjection'
 
 function formatGoalDate(dateStr: string): string {
   const d = new Date(dateStr)
@@ -732,95 +645,104 @@ export function AnalyticsSavers() {
                           </button>
                         </div>
                       </div>
-                      {/* Row 5: on-track projection badge (only when a target date is set) */}
-                      {projection && projection.monthsRemaining > 0 && (
-                        <div
-                          className="d-flex justify-content-end mt-2 pt-2"
-                          style={{
-                            borderTop:
-                              '1px solid var(--bs-border-color, var(--vantura-border))',
-                          }}
-                        >
-                          {projection.lastMonthCents <= 0 ? (
-                            <span className="badge bg-secondary">
-                              No history
-                            </span>
-                          ) : projection.onTrack &&
-                            Number.isFinite(projection.requiredMonthlyCents) ? (
-                            <OverlayTrigger
-                              placement="top"
-                              container={document.body}
-                              overlay={
-                                <Tooltip>
-                                  <div>
-                                    Need $
-                                    {formatMoney(
-                                      projection.requiredMonthlyCents
-                                    )}
-                                    /mo to reach goal by{' '}
-                                    {formatGoalDate(activeGoalDate!)}
-                                  </div>
-                                  <div style={{ opacity: 0.75 }}>
-                                    Last mo. $
-                                    {formatMoney(projection.lastMonthCents)} —
-                                    at that rate you're ahead of pace
-                                  </div>
-                                </Tooltip>
-                              }
-                            >
-                              <span
-                                className="badge bg-success"
-                                style={{ cursor: 'default' }}
-                              >
-                                On track
+                      {/* Row 5: on-track projection badge (target date set, goal not yet reached) */}
+                      {projection &&
+                        !goalReached &&
+                        projection.monthsRemaining > 0 && (
+                          <div
+                            className="d-flex justify-content-end mt-2 pt-2"
+                            style={{
+                              borderTop:
+                                '1px solid var(--bs-border-color, var(--vantura-border))',
+                            }}
+                          >
+                            {projection.lastMonthCents <= 0 ? (
+                              <span className="badge bg-secondary">
+                                No history
                               </span>
-                            </OverlayTrigger>
-                          ) : projection.onTrack ? (
-                            <span className="badge bg-success">On track</span>
-                          ) : (
-                            <OverlayTrigger
-                              placement="top"
-                              container={document.body}
-                              overlay={
-                                <Tooltip>
-                                  <div>
-                                    <span
-                                      style={{
-                                        color: 'var(--vantura-warning)',
-                                      }}
-                                    >
-                                      Need $
+                            ) : projection.onTrack &&
+                              Number.isFinite(
+                                projection.requiredMonthlyCents
+                              ) ? (
+                              <OverlayTrigger
+                                placement="top"
+                                container={document.body}
+                                overlay={
+                                  <Tooltip>
+                                    <div>
+                                      At $
+                                      {formatMoney(projection.lastMonthCents)}
+                                      /mo you&apos;ll reach $
+                                      {formatMoney(goalCents)}
+                                      {projection.projectedReachDate
+                                        ? ` around ${formatGoalDate(projection.projectedReachDate)}`
+                                        : ''}
+                                    </div>
+                                    <div style={{ opacity: 0.75 }}>
+                                      {projection.monthsEarly != null &&
+                                      projection.monthsEarly >= 1
+                                        ? `About ${projection.monthsEarly} month${projection.monthsEarly === 1 ? '' : 's'} before your ${formatGoalDate(activeGoalDate!)} target`
+                                        : `On pace for your ${formatGoalDate(activeGoalDate!)} target`}
+                                    </div>
+                                  </Tooltip>
+                                }
+                              >
+                                <span
+                                  className="badge bg-success"
+                                  style={{ cursor: 'default' }}
+                                >
+                                  {projection.monthsEarly != null &&
+                                  projection.monthsEarly >= 1
+                                    ? `~${projection.monthsEarly} mo early`
+                                    : 'On track'}
+                                </span>
+                              </OverlayTrigger>
+                            ) : projection.onTrack ? (
+                              <span className="badge bg-success">On track</span>
+                            ) : (
+                              <OverlayTrigger
+                                placement="top"
+                                container={document.body}
+                                overlay={
+                                  <Tooltip>
+                                    <div>
+                                      <span
+                                        style={{
+                                          color: 'var(--vantura-warning)',
+                                        }}
+                                      >
+                                        Need $
+                                        {formatMoney(
+                                          projection.requiredMonthlyCents
+                                        )}
+                                        /mo
+                                      </span>{' '}
+                                      to reach goal by{' '}
+                                      {formatGoalDate(activeGoalDate!)}
+                                    </div>
+                                    <div style={{ opacity: 0.75 }}>
+                                      Last mo. $
+                                      {formatMoney(projection.lastMonthCents)} ·
+                                      +$
                                       {formatMoney(
-                                        projection.requiredMonthlyCents
+                                        projection.requiredMonthlyCents -
+                                          projection.lastMonthCents
                                       )}
-                                      /mo
-                                    </span>{' '}
-                                    to reach goal by{' '}
-                                    {formatGoalDate(activeGoalDate!)}
-                                  </div>
-                                  <div style={{ opacity: 0.75 }}>
-                                    Last mo. $
-                                    {formatMoney(projection.lastMonthCents)} ·
-                                    +$
-                                    {formatMoney(
-                                      projection.requiredMonthlyCents -
-                                        projection.lastMonthCents
-                                    )}
-                                    /mo more needed
-                                  </div>
-                                </Tooltip>
-                              }
-                            >
-                              <span
-                                className="badge bg-warning text-dark"
-                                style={{ cursor: 'default' }}
+                                      /mo more needed
+                                    </div>
+                                  </Tooltip>
+                                }
                               >
-                                Behind pace
-                              </span>
-                            </OverlayTrigger>
-                          )}
-                        </div>
-                      )}
+                                <span
+                                  className="badge bg-warning text-dark"
+                                  style={{ cursor: 'default' }}
+                                >
+                                  Behind pace
+                                </span>
+                              </OverlayTrigger>
+                            )}
+                          </div>
+                        )}
                     </>
                   ) : (
                     <button

--- a/src/pages/analytics/saverProjection.test.ts
+++ b/src/pages/analytics/saverProjection.test.ts
@@ -1,0 +1,136 @@
+import { describe, it, expect } from 'vitest'
+import type { SaverMonthlyFlowPoint } from '@/services/accounts'
+import { computeProjection, deriveMonthlyBalances } from './saverProjection'
+
+/** A flow array whose most-recent *complete* month has the given saving rate. */
+function flowAtRate(rateCents: number): SaverMonthlyFlowPoint[] {
+  return [
+    { monthLabel: "Dec '25", flowCents: -rateCents, txCount: 1 },
+    // trailing (in-progress) month — computeProjection drops the last element
+    { monthLabel: "Jan '26", flowCents: 0, txCount: 0 },
+  ]
+}
+
+// Mid-month values so a machine's UTC offset can't flip the month the pre-existing
+// local-vs-UTC date parsing in computeProjection lands on.
+const NOW = new Date(2026, 0, 15) // 15 Jan 2026, local
+const IN_6_MONTHS = '2026-07-15'
+
+/** Local month/year of an ISO date — matches how the card formats projectedReachDate. */
+function localYm(iso: string): string {
+  const d = new Date(iso)
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}`
+}
+
+describe('computeProjection — #30 ahead-of-pace framing', () => {
+  it('reports how many months early the goal is reached when ahead of pace', () => {
+    const r = computeProjection(
+      40_000,
+      100_000,
+      flowAtRate(20_000),
+      IN_6_MONTHS,
+      NOW
+    )
+    // gap 60k / 20k per month = 3 months; target is 6 months out.
+    expect(r.onTrack).toBe(true)
+    expect(r.monthsRemaining).toBe(6)
+    expect(r.monthsToGoal).toBe(3)
+    expect(r.monthsEarly).toBe(3)
+    expect(localYm(r.projectedReachDate!)).toBe('2026-04') // Jan + 3 months
+  })
+
+  it('rounds partial months up (the line is crossed mid-month)', () => {
+    const r = computeProjection(
+      40_000,
+      100_000,
+      flowAtRate(25_000),
+      IN_6_MONTHS,
+      NOW
+    )
+    // 60k / 25k = 2.4 -> 3 months
+    expect(r.monthsToGoal).toBe(3)
+    expect(r.monthsEarly).toBe(3)
+  })
+
+  it('is on pace (0 months early) when the rate exactly matches the requirement', () => {
+    const r = computeProjection(
+      40_000,
+      100_000,
+      flowAtRate(10_000),
+      IN_6_MONTHS,
+      NOW
+    )
+    expect(r.onTrack).toBe(true)
+    expect(r.monthsToGoal).toBe(6)
+    expect(r.monthsEarly).toBe(0)
+  })
+
+  it('reports negative monthsEarly and onTrack=false when behind pace', () => {
+    const r = computeProjection(
+      40_000,
+      100_000,
+      flowAtRate(5_000),
+      IN_6_MONTHS,
+      NOW
+    )
+    expect(r.onTrack).toBe(false)
+    expect(r.monthsToGoal).toBe(12)
+    expect(r.monthsEarly).toBe(-6)
+  })
+
+  it('has no projection when there is no positive saving rate', () => {
+    const r = computeProjection(
+      40_000,
+      100_000,
+      flowAtRate(0),
+      IN_6_MONTHS,
+      NOW
+    )
+    expect(r.monthsToGoal).toBeNull()
+    expect(r.monthsEarly).toBeNull()
+    expect(r.projectedReachDate).toBeNull()
+  })
+
+  it('treats an already-covered goal as reached now (monthsToGoal 0)', () => {
+    const r = computeProjection(
+      120_000,
+      100_000,
+      flowAtRate(5_000),
+      IN_6_MONTHS,
+      NOW
+    )
+    expect(r.monthsToGoal).toBe(0)
+    expect(r.monthsEarly).toBe(6)
+    expect(localYm(r.projectedReachDate!)).toBe('2026-01')
+  })
+})
+
+describe('deriveMonthlyBalances', () => {
+  it('walks the current balance backwards through the monthly flow', () => {
+    const flow: SaverMonthlyFlowPoint[] = [
+      { monthLabel: "Nov '25", flowCents: -10_000, txCount: 1 },
+      { monthLabel: "Dec '25", flowCents: -20_000, txCount: 2 },
+    ]
+    // b starts at 100k -> unshift {Dec, 100k}; b += Dec.flow (-20k) -> 80k;
+    // unshift {Nov, 80k}; b += Nov.flow (-10k) -> 70k (unused).
+    const out = deriveMonthlyBalances(flow, 'sav-1', 100_000)
+    expect(out).toEqual([
+      { saver_id: 'sav-1', snapshot_date: '2025-11-01', balance_cents: 80_000 },
+      {
+        saver_id: 'sav-1',
+        snapshot_date: '2025-12-01',
+        balance_cents: 100_000,
+      },
+    ])
+  })
+
+  it('floors reconstructed balances at zero', () => {
+    const flow: SaverMonthlyFlowPoint[] = [
+      { monthLabel: "Nov '25", flowCents: -5_000, txCount: 1 },
+      { monthLabel: "Dec '25", flowCents: -50_000, txCount: 2 },
+    ]
+    const out = deriveMonthlyBalances(flow, 'sav-1', 10_000)
+    expect(out[0].balance_cents).toBe(0) // would be -40k
+    expect(out[1].balance_cents).toBe(10_000)
+  })
+})

--- a/src/pages/analytics/saverProjection.ts
+++ b/src/pages/analytics/saverProjection.ts
@@ -1,0 +1,124 @@
+/**
+ * Pure projection math for the Savers page, extracted from `AnalyticsSavers.tsx`
+ * so it is unit-testable (same reason `trackerPeriodHistory.ts` was split out).
+ */
+import type {
+  SaverBalanceSnapshot,
+  SaverMonthlyFlowPoint,
+} from '@/services/accounts'
+
+const MONTH_MAP: Record<string, string> = {
+  Jan: '01',
+  Feb: '02',
+  Mar: '03',
+  Apr: '04',
+  May: '05',
+  Jun: '06',
+  Jul: '07',
+  Aug: '08',
+  Sep: '09',
+  Oct: '10',
+  Nov: '11',
+  Dec: '12',
+}
+
+/**
+ * Reconstruct end-of-month balances from flow data, working backwards from the
+ * current balance so both saver charts share one source and time window.
+ */
+export function deriveMonthlyBalances(
+  flow: SaverMonthlyFlowPoint[],
+  saverId: string,
+  currentBalance: number
+): SaverBalanceSnapshot[] {
+  const result: SaverBalanceSnapshot[] = []
+  let b = currentBalance
+  for (let i = flow.length - 1; i >= 0; i--) {
+    const p = flow[i]
+    // "Jun '26" → "2026-06-01"
+    const [mon, yr] = p.monthLabel.split(' ')
+    const date = `20${yr.slice(1)}-${MONTH_MAP[mon]}-01`
+    result.unshift({
+      saver_id: saverId,
+      snapshot_date: date,
+      balance_cents: Math.max(0, b),
+    })
+    // balance at end of previous month = balance at end of this month + this month's flow
+    b += p.flowCents
+  }
+  return result
+}
+
+export interface ProjectionResult {
+  onTrack: boolean
+  lastMonthCents: number
+  projectedBalanceCents: number
+  monthsRemaining: number
+  requiredMonthlyCents: number
+  /** Whole months at the current rate to close the gap (rounded up). null when there is no positive rate. */
+  monthsToGoal: number | null
+  /** monthsRemaining − monthsToGoal: positive = reached this many months before the target. null when monthsToGoal is null. */
+  monthsEarly: number | null
+  /** ISO date the goal is projected to be reached at the current rate. null when monthsToGoal is null. */
+  projectedReachDate: string | null
+}
+
+export function computeProjection(
+  currentBalanceCents: number,
+  goalCents: number,
+  monthlyFlow: SaverMonthlyFlowPoint[],
+  goalDate: string,
+  now: Date = new Date()
+): ProjectionResult {
+  // Use the most recent complete month as the projected rate — matches Up Bank's
+  // payday-split behaviour where each month's contribution is consistent and
+  // the latest month is the most representative of the ongoing rate.
+  const complete = monthlyFlow.slice(0, -1)
+  const lastMonth = complete[complete.length - 1]
+  // flowCents is negative for savings; negate to get positive = monthly saving rate
+  const lastMonthCents = lastMonth ? -lastMonth.flowCents : 0
+
+  const target = new Date(goalDate)
+  const monthsRemaining = Math.max(
+    0,
+    (target.getFullYear() - now.getFullYear()) * 12 +
+      (target.getMonth() - now.getMonth())
+  )
+
+  const projectedBalanceCents =
+    currentBalanceCents + lastMonthCents * monthsRemaining
+  const requiredMonthlyCents =
+    monthsRemaining > 0
+      ? (goalCents - currentBalanceCents) / monthsRemaining
+      : Infinity
+
+  // How long until the goal is reached at the current rate — solve for months,
+  // rounded up (the line is crossed partway through that month). 0 if already
+  // covered; null if there is no positive rate to project from.
+  const gapCents = goalCents - currentBalanceCents
+  const monthsToGoal =
+    gapCents <= 0
+      ? 0
+      : lastMonthCents > 0
+        ? Math.ceil(gapCents / lastMonthCents)
+        : null
+  const monthsEarly =
+    monthsToGoal != null ? monthsRemaining - monthsToGoal : null
+  let projectedReachDate: string | null = null
+  if (monthsToGoal != null) {
+    const reach = new Date(now)
+    reach.setMonth(reach.getMonth() + monthsToGoal)
+    projectedReachDate = reach.toISOString()
+  }
+
+  return {
+    onTrack: projectedBalanceCents >= goalCents,
+    lastMonthCents,
+    projectedBalanceCents,
+    monthsRemaining,
+    requiredMonthlyCents,
+    monthsToGoal,
+    monthsEarly,
+    projectedReachDate,
+  }
+}


### PR DESCRIPTION
Closes #30.

`computeProjection()` used to answer only "goal hit by the target date, yes/no" (+ the required rate on hover). It now also **solves for when** the goal is reached at the current rate:

- `monthsToGoal` — `ceil((goal − balance) / lastMonthCents)`; `0` if already covered, `null` if there's no positive rate.
- `monthsEarly` — `monthsRemaining − monthsToGoal` (positive = ahead).
- `projectedReachDate` — the projected month.

**UI:** when ahead of pace, the badge reads **`~N mo early`** instead of a plain "On track", and its tooltip says *"At $X/mo you'll reach $Y around «month» — About N months before your «target» target"*. On-pace (0 early) still shows "On track". The behind-pace path is unchanged.

The pace block is now **hidden once the goal is reached** (`achieved_at` set) — a pace badge on an already-reached goal was noise, newly visible because #29 made "reached" sticky.

**Refactor:** `computeProjection` + `deriveMonthlyBalances` extracted from `AnalyticsSavers.tsx` into a pure `src/pages/analytics/saverProjection.ts` (same rationale as `trackerPeriodHistory.ts`), with a new unit test — ahead / rounds-up / on-pace / behind / no-rate / already-covered, verified tz-stable (`Australia/Melbourne` + `UTC`).

567 unit tests green · `npm run validate` + `npm run build` clean.

Docs (`docs/` gitignored): `savers/OVERVIEW.md` pace section + `CONTEXT.md` "Pace projection" glossary — to apply on approval.

🤖 Generated with [Claude Code](https://claude.com/claude-code)