### PR TITLE
Trackers: route frequency / reset-day changes through config history (#38)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 
+- **Changing a tracker's frequency or reset day no longer throws away the in-flight period.** It used to re-anchor the period to today and wipe the tracker's whole config history. Now it writes a *transitional period*: the current period keeps its start and runs to the new cadence's next reset, the pre-change days stay judged against the old cadence, and the new cadence + budget take effect the next day — the same "next day, split the period" behaviour a budget change already had (#16 / ADR-0014). Historical period views are unchanged. New nullable `tracker_config_history.reset_frequency` column (schema v45), profile export payload v7.
 - **Weekly Insights groups by parent category:** spending categories are now grouped under their real Up Bank parent (Home, Transport, Good Life, Personal) in a fixed order, sorted by spend within each group, with the smallest categories folded into a single "Other" row once more than 7 categories have spend in a week. See `src/services/insights.ts`, `src/components/charts/InsightsBarChart.tsx`.
 
 ### Fixed

--- a/src/db/schema.migration.test.ts
+++ b/src/db/schema.migration.test.ts
@@ -159,7 +159,7 @@ describe('v36 migration: bank-statement-import removal', () => {
       `SELECT value FROM app_settings WHERE key = 'schema_version'`
     )
     expect(versionRow[0].values[0][0]).toBe(String(SCHEMA_VERSION))
-    expect(SCHEMA_VERSION).toBe(44)
+    expect(SCHEMA_VERSION).toBe(45)
 
     // The credit-card-import account is gone.
     const ccAccount = db.exec(`SELECT * FROM accounts WHERE id = 'cc-visa'`)
@@ -946,6 +946,55 @@ describe('v44 migration: saver goal history', () => {
     runMigrations(db)
     const rows = db.exec(`SELECT COUNT(*) FROM saver_goal_history`)
     expect(rows[0].values[0][0]).toBe(0)
+    expect(() => runMigrations(db)).not.toThrow()
+    db.close()
+  })
+})
+
+/**
+ * Minimal v44-shaped fixture for the v45 migration (#38 — frequency-through-history):
+ * `tracker_config_history` without the new `reset_frequency` column, one row.
+ */
+function buildLegacyV44Database(): Database {
+  const db = new SQL.Database()
+  db.run(
+    `CREATE TABLE app_settings (key TEXT PRIMARY KEY, value TEXT NOT NULL)`
+  )
+  db.run(
+    `INSERT INTO app_settings (key, value) VALUES ('schema_version', '44')`
+  )
+  db.run(`
+    CREATE TABLE tracker_config_history (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      tracker_id INTEGER NOT NULL,
+      effective_from TEXT NOT NULL,
+      budget_amount INTEGER NOT NULL,
+      created_at TEXT NOT NULL
+    )
+  `)
+  db.run(
+    `INSERT INTO tracker_config_history (tracker_id, effective_from, budget_amount, created_at)
+     VALUES (1, '2026-03-01', 30000, '2026-03-01T00:00:00.000Z')`
+  )
+  return db
+}
+
+describe('v45 migration: tracker_config_history.reset_frequency', () => {
+  it('adds the nullable column, leaves existing rows NULL, and is idempotent', () => {
+    const db = buildLegacyV44Database()
+
+    runMigrations(db)
+
+    expect(readSetting(db, 'schema_version')).toBe(String(SCHEMA_VERSION))
+    const cols = db.exec(`PRAGMA table_info(tracker_config_history)`)
+    const colNames = cols[0].values.map((r) => String(r[1]))
+    expect(colNames).toContain('reset_frequency')
+
+    const row = db.exec(
+      `SELECT budget_amount, reset_frequency FROM tracker_config_history`
+    )
+    expect(row[0].values[0]).toEqual([30000, null])
+
     expect(() => runMigrations(db)).not.toThrow()
     db.close()
   })

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -5,7 +5,7 @@
 
 import type { Database } from 'sql.js'
 
-const SCHEMA_VERSION = 44
+const SCHEMA_VERSION = 45
 
 function tableExists(database: Database, name: string): boolean {
   const stmt = database.prepare(
@@ -106,6 +106,7 @@ const DDL_STATEMENTS = [
     tracker_id INTEGER NOT NULL,
     effective_from TEXT NOT NULL,
     budget_amount INTEGER NOT NULL,
+    reset_frequency TEXT,
     created_at TEXT NOT NULL,
     FOREIGN KEY (tracker_id) REFERENCES trackers(id) ON DELETE CASCADE
   )`,
@@ -1240,6 +1241,27 @@ export function runMigrations(database: Database): void {
     database.run(
       `INSERT OR REPLACE INTO app_settings (key, value) VALUES ('schema_version', ?)`,
       ['44']
+    )
+  }
+
+  // #38 — tracker_config_history.reset_frequency. A frequency / reset-day change
+  // now writes a transitional period through the history table (like a budget
+  // edit) instead of wiping it. Each config row records the cadence its
+  // budget_amount is denominated in; NULL means "the period's own cadence" —
+  // correct for every existing row (cadence never varied), so no backfill.
+  if (version < 45) {
+    const tchCols = database.exec(`PRAGMA table_info(tracker_config_history)`)
+    const tchHasFreq = (tchCols[0]?.values ?? []).some(
+      (r) => String(r[1]) === 'reset_frequency'
+    )
+    if (tableExists(database, 'tracker_config_history') && !tchHasFreq) {
+      database.run(
+        `ALTER TABLE tracker_config_history ADD COLUMN reset_frequency TEXT`
+      )
+    }
+    database.run(
+      `INSERT OR REPLACE INTO app_settings (key, value) VALUES ('schema_version', ?)`,
+      ['45']
     )
   }
 }

--- a/src/lib/monthlyEquivalent.ts
+++ b/src/lib/monthlyEquivalent.ts
@@ -47,7 +47,7 @@ export function toMonthlyEquivalentCents(
   return Math.round(Math.max(0, amountCents) * mult)
 }
 
-function toYearlyCents(amountCents: number, frequency: string): number {
+export function toYearlyCents(amountCents: number, frequency: string): number {
   const safe = Math.max(0, amountCents)
   switch (resolveFrequency(frequency)) {
     case 'WEEKLY':
@@ -63,6 +63,19 @@ function toYearlyCents(amountCents: number, frequency: string): number {
     default:
       return 0
   }
+}
+
+/**
+ * Per-day rate of a budget at a given frequency (`yearly / 365`). Used to price a
+ * partial period-segment whose cadence differs from the enclosing period's — e.g.
+ * the transitional period after a tracker frequency change (#38). Not exact for
+ * a whole calendar month, so callers only use it for sub-period spans.
+ */
+export function toDailyRateCents(
+  amountCents: number,
+  frequency: string
+): number {
+  return toYearlyCents(amountCents, frequency) / 365
 }
 
 /**

--- a/src/services/profileExport.test.ts
+++ b/src/services/profileExport.test.ts
@@ -1161,7 +1161,7 @@ describe('profile import writers: real-DB coverage (#36)', () => {
 
       const payload = buildExportPayload()
 
-      expect(payload.version).toBe(6)
+      expect(payload.version).toBe(7)
       expect(payload.manualAccounts?.map((a) => a.name)).toEqual([
         'Mortgage',
         'Shares',
@@ -1454,7 +1454,7 @@ describe('profile import writers: real-DB coverage (#36)', () => {
       insertGoal('sav-1', 400000, { date: '2026-12-01' })
 
       const payload = buildExportPayload()
-      expect(payload.version).toBe(6)
+      expect(payload.version).toBe(7)
       expect(payload.saverGoals).toEqual([
         {
           saver_id: 'sav-1',

--- a/src/services/profileExport.ts
+++ b/src/services/profileExport.ts
@@ -20,7 +20,7 @@ import { SCHEMA_VERSION } from '@/db/schema'
 import { writeTrackerConfigVersion } from './trackers'
 
 /** Export format version for the encrypted payload */
-const EXPORT_PAYLOAD_VERSION = 6
+const EXPORT_PAYLOAD_VERSION = 7
 
 /** File wrapper version for the outer JSON structure */
 const EXPORT_FILE_VERSION = 1
@@ -117,6 +117,8 @@ export interface TrackerConfigHistoryExportRow {
   effective_from: string
   budget_amount: number
   category_ids: string[]
+  /** #38 — cadence this row's budget is denominated in; set only on a frequency-change row. Absent before payload v7. */
+  reset_frequency?: string | null
 }
 
 export interface UpcomingChargeExportRow {
@@ -288,18 +290,19 @@ function collectTrackerConfigHistory(): TrackerConfigHistoryExportRow[] {
   const db = getDb()
   if (!db) return []
   const stmt = db.prepare(
-    `SELECT id, tracker_id, effective_from, budget_amount
+    `SELECT id, tracker_id, effective_from, budget_amount, reset_frequency
      FROM tracker_config_history ORDER BY tracker_id, effective_from, id`
   )
   const byConfigId = new Map<number, TrackerConfigHistoryExportRow>()
   const rows: TrackerConfigHistoryExportRow[] = []
   while (stmt.step()) {
-    const r = stmt.get() as [number, number, string, number]
+    const r = stmt.get() as [number, number, string, number, string | null]
     const row: TrackerConfigHistoryExportRow = {
       tracker_id: r[1],
       effective_from: String(r[2]).slice(0, 10),
       budget_amount: r[3],
       category_ids: [],
+      reset_frequency: r[4] ?? null,
     }
     byConfigId.set(r[0], row)
     rows.push(row)
@@ -843,7 +846,8 @@ export function replaceTrackers(
       newTrackerId,
       ch.effective_from.slice(0, 10),
       ch.budget_amount,
-      catIds
+      catIds,
+      typeof ch.reset_frequency === 'string' ? ch.reset_frequency : null
     )
     trackersWithHistory.add(newTrackerId)
   }

--- a/src/services/trackerConfigHistory.test.ts
+++ b/src/services/trackerConfigHistory.test.ts
@@ -33,6 +33,7 @@ const {
 } = await import('./trackers')
 const { buildExportPayload, replaceTrackers } = await import('./profileExport')
 const { localDateString } = await import('@/lib/format')
+const { toDailyRateCents } = await import('@/lib/monthlyEquivalent')
 
 beforeAll(async () => {
   SQL = await initSqlJs()
@@ -50,19 +51,24 @@ beforeEach(async () => {
 
 // ─── pure core: splitPeriodIntoSegments ──────────────────────────────────────
 
-type Cfg = Pick<TrackerConfigVersion, 'budget_amount' | 'category_ids'>
+type Cfg = Pick<
+  TrackerConfigVersion,
+  'budget_amount' | 'category_ids' | 'reset_frequency'
+>
 
 function version(
   id: number,
   effectiveFrom: string,
   budget: number,
-  cats: string[]
+  cats: string[],
+  resetFrequency: string | null = null
 ): TrackerConfigVersion {
   return {
     id,
     effective_from: effectiveFrom,
     budget_amount: budget,
     category_ids: cats,
+    reset_frequency: resetFrequency,
   }
 }
 
@@ -76,7 +82,11 @@ function fakeSpend(txns: { cat: string; cents: number; date: string }[]) {
 
 describe('splitPeriodIntoSegments (pure core)', () => {
   const genesis = version(1, '2026-03-01', 30000, ['groceries'])
-  const fallback: Cfg = { budget_amount: 30000, category_ids: ['groceries'] }
+  const fallback: Cfg = {
+    budget_amount: 30000,
+    category_ids: ['groceries'],
+    reset_frequency: null,
+  }
 
   it('is one full-budget segment when nothing changed', () => {
     const segs = splitPeriodIntoSegments(
@@ -133,6 +143,52 @@ describe('splitPeriodIntoSegments (pure core)', () => {
       fakeSpend([])
     )
     expect(segs.reduce((s, seg) => s + seg.budget, 0)).toBe(30000)
+  })
+
+  it('#38 — a partial segment whose config carries a reset_frequency is priced at that cadence daily rate', () => {
+    // Transitional period after a WEEKLY→MONTHLY change: 19-day window, split at
+    // the "tomorrow" boundary. Seg 1 = 4 days old WEEKLY, seg 2 = 15 days new MONTHLY.
+    const segs = splitPeriodIntoSegments(
+      '2026-03-01',
+      '2026-03-20', // 19 days
+      [
+        version(1, '2026-03-01', 30000, ['groceries'], 'WEEKLY'),
+        version(2, '2026-03-05', 120000, ['groceries'], 'MONTHLY'),
+      ],
+      fallback,
+      fakeSpend([])
+    )
+    expect(segs).toHaveLength(2)
+    expect(segs[0].budget).toBe(
+      Math.round(toDailyRateCents(30000, 'WEEKLY') * 4)
+    )
+    expect(segs[1].budget).toBe(
+      Math.round(toDailyRateCents(120000, 'MONTHLY') * 15)
+    )
+  })
+
+  it('#38 — a reset_frequency tag is ignored for a full-period single segment', () => {
+    const segs = splitPeriodIntoSegments(
+      '2026-03-01',
+      '2026-03-31',
+      [version(1, '2026-03-01', 120000, ['groceries'], 'MONTHLY')],
+      fallback,
+      fakeSpend([])
+    )
+    expect(segs).toHaveLength(1)
+    expect(segs[0].budget).toBe(120000) // budget_amount verbatim, not daily-rate
+  })
+
+  it('#38 — a NULL reset_frequency still prorates by period days (regression guard)', () => {
+    const segs = splitPeriodIntoSegments(
+      '2026-03-01',
+      '2026-03-08',
+      [genesis, version(2, '2026-03-05', 40000, ['groceries'])], // reset_frequency null
+      fallback,
+      fakeSpend([])
+    )
+    expect(segs[0].budget).toBe(Math.round((30000 * 4) / 7))
+    expect(segs[1].budget).toBe(Math.round((40000 * 3) / 7))
   })
 
   it('counts a category only while it was part of the tracker (add mid-period)', () => {
@@ -462,12 +518,61 @@ describe('updateTracker records config versions', () => {
     expect(history[1].category_ids.sort()).toEqual(['dining', 'groceries'])
   })
 
-  it('a frequency change resets history to a fresh genesis row', () => {
+  it('a frequency change keeps the timeline: old cadence stamped, new cadence effective tomorrow (#38)', () => {
     const id = createTracker('Food', 30000, 'WEEKLY', 1, ['groceries'])
-    updateTracker(id, 'Food', 45000, 'WEEKLY', 1, ['groceries'])
-    expect(getTrackerConfigHistory(id)).toHaveLength(2)
+    const before = db.exec(
+      `SELECT last_reset_date FROM trackers WHERE id = ?`,
+      [id]
+    )[0].values[0][0] as string
 
     updateTracker(id, 'Food', 45000, 'MONTHLY', 1, ['groceries'])
+
+    // Current period start is untouched; it now ends at the new-cadence boundary.
+    const after = db.exec(
+      `SELECT last_reset_date, next_reset_date FROM trackers WHERE id = ?`,
+      [id]
+    )[0].values[0]
+    expect(after[0]).toBe(before)
+    expect((after[1] as string) > localDateString()).toBe(true) // boundary is in the future
+
+    const history = getTrackerConfigHistory(id)
+    expect(history.length).toBeGreaterThanOrEqual(2) // NOT wiped
+    // genesis (still at the period start) now records the OLD cadence
+    expect(history[0]).toMatchObject({
+      effective_from: before,
+      budget_amount: 30000,
+      reset_frequency: 'WEEKLY',
+    })
+    // new cadence + budget from tomorrow
+    expect(history[history.length - 1]).toMatchObject({
+      effective_from: tomorrow,
+      budget_amount: 45000,
+      reset_frequency: 'MONTHLY',
+    })
+  })
+
+  it('a reset-day-only change gets the same transitional treatment', () => {
+    const id = createTracker('Food', 30000, 'WEEKLY', 1, ['groceries']) // Monday
+    updateTracker(id, 'Food', 30000, 'WEEKLY', 4, ['groceries']) // Thursday
+
+    const history = getTrackerConfigHistory(id)
+    expect(history.length).toBeGreaterThanOrEqual(2)
+    expect(history[0].reset_frequency).toBe('WEEKLY')
+    expect(history[history.length - 1]).toMatchObject({
+      effective_from: tomorrow,
+      reset_frequency: 'WEEKLY',
+    })
+  })
+
+  it('a frequency change on broken data (future-dated period start) still wipes and re-anchors', () => {
+    const id = createTracker('Food', 30000, 'WEEKLY', 1, ['groceries'])
+    db.run(
+      `UPDATE trackers SET last_reset_date = '2099-01-01', next_reset_date = '2099-01-08' WHERE id = ?`,
+      [id]
+    )
+
+    updateTracker(id, 'Food', 45000, 'MONTHLY', 1, ['groceries'])
+
     const history = getTrackerConfigHistory(id)
     expect(history).toHaveLength(1)
     expect(history[0].budget_amount).toBe(45000)
@@ -536,6 +641,44 @@ describe('profile export / import round-trip', () => {
     expect(history).toHaveLength(1)
     expect(history[0].budget_amount).toBe(30000)
     expect(history[0].category_ids).toEqual(['groceries'])
+  })
+
+  it('#38 — reset_frequency survives the export → import round-trip', () => {
+    const id = createTracker('Food', 30000, 'WEEKLY', 1, ['groceries'])
+    updateTracker(id, 'Food', 120000, 'MONTHLY', 1, ['groceries'])
+
+    const payload = buildExportPayload()
+    const freqs = payload
+      .trackerConfigHistory!.map((r) => r.reset_frequency)
+      .sort()
+    expect(freqs).toEqual(['MONTHLY', 'WEEKLY'])
+
+    replaceTrackers(
+      payload.trackers,
+      payload.trackerCategories,
+      payload.trackerConfigHistory
+    )
+    const history = getTrackerConfigHistory(trackerIdByName('Food'))
+    expect(history[0].reset_frequency).toBe('WEEKLY')
+    expect(history[history.length - 1].reset_frequency).toBe('MONTHLY')
+  })
+
+  it('#38 — a pre-v7 config-history row (no reset_frequency) imports as NULL', () => {
+    createTracker('Food', 30000, 'WEEKLY', 1, ['groceries'])
+    const payload = buildExportPayload()
+    const stripped = payload.trackerConfigHistory!.map(
+      ({ tracker_id, effective_from, budget_amount, category_ids }) => ({
+        tracker_id,
+        effective_from,
+        budget_amount,
+        category_ids,
+      })
+    )
+
+    replaceTrackers(payload.trackers, payload.trackerCategories, stripped)
+
+    const history = getTrackerConfigHistory(trackerIdByName('Food'))
+    expect(history[0].reset_frequency).toBeNull()
   })
 })
 

--- a/src/services/trackers.ts
+++ b/src/services/trackers.ts
@@ -13,6 +13,7 @@ import {
 } from '@/lib/dateStr'
 import {
   toPeriodCents,
+  toDailyRateCents,
   type BudgetDisplayPeriod,
 } from '@/lib/monthlyEquivalent'
 
@@ -171,6 +172,11 @@ export interface TrackerConfigVersion {
   effective_from: string
   budget_amount: number
   category_ids: string[]
+  /**
+   * Cadence this row's `budget_amount` is denominated in. NULL = the enclosing
+   * period's own cadence (every row except those a frequency change wrote, #38).
+   */
+  reset_frequency: string | null
 }
 
 /**
@@ -184,7 +190,7 @@ export function getTrackerConfigHistory(
   const db = getDb()
   if (!db) return []
   const stmt = db.prepare(
-    `SELECT id, effective_from, budget_amount
+    `SELECT id, effective_from, budget_amount, reset_frequency
      FROM tracker_config_history
      WHERE tracker_id = ?
      ORDER BY effective_from ASC, id ASC`
@@ -192,12 +198,13 @@ export function getTrackerConfigHistory(
   stmt.bind([trackerId])
   const versions: TrackerConfigVersion[] = []
   while (stmt.step()) {
-    const r = stmt.get() as [number, string, number]
+    const r = stmt.get() as [number, string, number, string | null]
     versions.push({
       id: r[0],
       effective_from: normDate(r[1]),
       budget_amount: r[2],
       category_ids: [],
+      reset_frequency: r[3],
     })
   }
   stmt.free()
@@ -237,7 +244,7 @@ export type CurrentPeriodInput = Pick<
 
 type SegmentConfig = Pick<
   TrackerConfigVersion,
-  'budget_amount' | 'category_ids'
+  'budget_amount' | 'category_ids' | 'reset_frequency'
 >
 
 /**
@@ -249,6 +256,14 @@ type SegmentConfig = Pick<
  * from `spendLookup` over that config's category set. `fallback` is used for any
  * day no `history` row covers. No DB — `computeCurrentPeriodSegments` is the thin
  * wrapper that supplies `history`, `fallback`, and the lookup.
+ *
+ * Exception (#38): a **partial** segment (`segDays !== periodDays`) whose config
+ * carries a `reset_frequency` — written only by a frequency / reset-day change —
+ * is priced at that cadence's daily rate (`toDailyRateCents × segDays`) instead,
+ * because its `budget_amount` is denominated in a different cadence than the
+ * transitional period it sits in. A full-period single segment always uses
+ * `budget_amount` directly, cadence tag or not (daily-rate is not exact over a
+ * whole calendar month).
  *
  * `history` MUST be ordered oldest `effective_from` first (the `configAsOf` walk
  * short-circuits on that); `getTrackerConfigHistory` guarantees it.
@@ -289,10 +304,15 @@ export function splitPeriodIntoSegments(
     const e = cutEnds[i]
     const cfg = configAsOf(s)
     const segDays = daysBetween(s, e)
+    const isPartial = segDays !== periodDays
     const budget =
-      periodDays > 0
-        ? Math.round((cfg.budget_amount * segDays) / periodDays)
-        : cfg.budget_amount
+      isPartial && cfg.reset_frequency
+        ? Math.round(
+            toDailyRateCents(cfg.budget_amount, cfg.reset_frequency) * segDays
+          )
+        : periodDays > 0
+          ? Math.round((cfg.budget_amount * segDays) / periodDays)
+          : cfg.budget_amount
     segments.push({
       start: s,
       end: e,
@@ -328,6 +348,7 @@ export function computeCurrentPeriodSegments(
   const fallback: SegmentConfig = {
     budget_amount: tracker.budget_amount,
     category_ids: getTrackerCategoryIds(tracker.id),
+    reset_frequency: null,
   }
   return splitPeriodIntoSegments(
     tracker.last_reset_date,
@@ -925,13 +946,18 @@ function assertCategoriesAvailable(
  * version for a tracker (#16) and its category set. The caller owns
  * `schedulePersist()`. Shared by createTracker, updateTracker, the demo seed and
  * profile import so the genesis / version insert lives in one place.
+ *
+ * `resetFrequency` (#38) is recorded only for rows a frequency / reset-day change
+ * writes — it tells the split calc this row's `budget_amount` is denominated in
+ * that cadence, not the enclosing period's. Left `null` by every other caller.
  */
 export function writeTrackerConfigVersion(
   db: NonNullable<ReturnType<typeof getDb>>,
   trackerId: number,
   effectiveFrom: string,
   budgetAmountCents: number,
-  categoryIds: string[]
+  categoryIds: string[],
+  resetFrequency: string | null = null
 ): void {
   const now = new Date().toISOString()
   const existing = db.exec(
@@ -940,19 +966,19 @@ export function writeTrackerConfigVersion(
   )
   let configId = Number(existing[0]?.values?.[0]?.[0] ?? 0)
   if (configId > 0) {
-    db.run(`UPDATE tracker_config_history SET budget_amount = ? WHERE id = ?`, [
-      budgetAmountCents,
-      configId,
-    ])
+    db.run(
+      `UPDATE tracker_config_history SET budget_amount = ?, reset_frequency = ? WHERE id = ?`,
+      [budgetAmountCents, resetFrequency, configId]
+    )
     db.run(
       `DELETE FROM tracker_config_history_categories WHERE config_id = ?`,
       [configId]
     )
   } else {
     db.run(
-      `INSERT INTO tracker_config_history (tracker_id, effective_from, budget_amount, created_at)
-       VALUES (?, ?, ?, ?)`,
-      [trackerId, effectiveFrom, budgetAmountCents, now]
+      `INSERT INTO tracker_config_history (tracker_id, effective_from, budget_amount, reset_frequency, created_at)
+       VALUES (?, ?, ?, ?, ?)`,
+      [trackerId, effectiveFrom, budgetAmountCents, resetFrequency, now]
     )
     configId = Number(
       db.exec(`SELECT last_insert_rowid()`)[0]?.values?.[0]?.[0] ?? 0
@@ -985,9 +1011,14 @@ export function deleteTrackerConfigHistory(
 }
 
 /**
- * Record the config-history effect of an `updateTracker` edit (#16):
- * - frequency / reset-day change → wipe history, write a fresh genesis at the
- *   new period start (frequency-through-history is a deferred follow-up);
+ * Record the config-history effect of an `updateTracker` edit (#16, #38):
+ * - frequency / reset-day change, transitional (the common case) → keep the
+ *   timeline; stamp every existing row (`effective_from <= today`) with the OLD
+ *   cadence so the split prices the pre-transition part of the transitional
+ *   period at that daily rate, then write a version effective tomorrow carrying
+ *   the NEW cadence + budget + categories;
+ * - frequency / reset-day change, non-transitional (no `existing`, or a broken
+ *   future-dated period start) → wipe history, write a fresh genesis;
  * - budget / category change → a version effective tomorrow so the current
  *   period splits at that boundary rather than being re-judged whole;
  * - pure rename → nothing.
@@ -1002,6 +1033,10 @@ function maintainConfigHistoryOnEdit(args: {
   newBudgetCents: number
   newCategoryIds: string[]
   needsPeriodReset: boolean
+  /** #38 — frequency/reset-day change that keeps the timeline (see updateTracker). */
+  transitionalFrequencyChange: boolean
+  /** The new tracker cadence (`resetFrequency`), stamped on the tomorrow row. */
+  newFreq: string
   newLastReset: string
   today: string
 }): void {
@@ -1013,17 +1048,49 @@ function maintainConfigHistoryOnEdit(args: {
     newBudgetCents,
     newCategoryIds,
     needsPeriodReset,
+    transitionalFrequencyChange,
+    newFreq,
     newLastReset,
     today,
   } = args
   if (needsPeriodReset) {
-    deleteTrackerConfigHistory(db, id)
+    if (!transitionalFrequencyChange || !existing) {
+      deleteTrackerConfigHistory(db, id)
+      writeTrackerConfigVersion(
+        db,
+        id,
+        newLastReset,
+        newBudgetCents,
+        newCategoryIds
+      )
+      return
+    }
+    // Transitional: the pre-transition part of the current period is priced
+    // against the old cadence's daily rate.
+    db.run(
+      `UPDATE tracker_config_history SET reset_frequency = ? WHERE tracker_id = ? AND effective_from <= ?`,
+      [existing.reset_frequency, id, today]
+    )
+    const hasBaseline = getTrackerConfigHistory(id).some(
+      (v) => v.effective_from <= newLastReset
+    )
+    if (!hasBaseline) {
+      writeTrackerConfigVersion(
+        db,
+        id,
+        newLastReset,
+        existing.budget_amount,
+        existingCats,
+        existing.reset_frequency
+      )
+    }
     writeTrackerConfigVersion(
       db,
       id,
-      newLastReset,
+      addDaysToDateStr(today, 1),
       newBudgetCents,
-      newCategoryIds
+      newCategoryIds,
+      newFreq
     )
     return
   }
@@ -1153,6 +1220,20 @@ export function updateTracker(
     lastReset = getLastResetDate(resetFrequency, resetDay, today)
     nextReset = getNextResetDate(resetFrequency, resetDay, lastReset)
   }
+
+  // #38 — a frequency / reset-day change normally becomes a *transitional
+  // period*: the current period keeps its start and ends at the new cadence's
+  // next reset, so no in-flight period is discarded and the config history
+  // survives. Skip it only for broken data — no `existing`, or a period start
+  // that isn't before the new boundary.
+  const transitionalFrequencyChange =
+    needsPeriodReset &&
+    !!existing &&
+    normalizeDateStr(existing.last_reset_date) < nextReset
+  if (transitionalFrequencyChange && existing) {
+    lastReset = normalizeDateStr(existing.last_reset_date)
+  }
+
   db.run(
     `UPDATE trackers SET name = ?, budget_amount = ?, reset_frequency = ?, reset_day = ?, last_reset_date = ?, next_reset_date = ? WHERE id = ?`,
     [
@@ -1181,6 +1262,8 @@ export function updateTracker(
     newBudgetCents: budgetAmountCents,
     newCategoryIds: categoryIds,
     needsPeriodReset,
+    transitionalFrequencyChange,
+    newFreq: resetFrequency,
     newLastReset: lastReset,
     today,
   })


### PR DESCRIPTION
Closes #38. Follow-up to #16 / ADR-0014.

## Before

A tracker **budget / category** edit takes effect next day and *splits* the current period (`tracker_config_history`). A **frequency / reset-day** change instead re-anchored `last_reset_date` / `next_reset_date` to *today* on the new cadence and **wiped the whole config history** — the in-flight period was discarded and a fresh period could silently start in the past.

## After — transitional period

Direction chosen with Okky: scoped like ADR-0014 (**current period only**). The backward period-walkers (`getPeriodBoundsForOffset` / `stepBackOnePeriod` / `getTrackerPeriodsInRange` / `getTrackerPeriodHistory`) and `recalculateTrackers` are **untouched** — historical periods keep the same current-cadence imprecision ADR-0014 already accepts. The full variable-cadence version was rejected as too high-risk for this module.

On a frequency / reset-day change, `updateTracker`:
- keeps the current period's **start**, sets its **end** to the new cadence's next natural reset (`>= tomorrow`) → `[oldStart, transitionBoundary)` is the transitional period;
- falls back to the old wipe + re-anchor only for broken data (no `existing`, or a future-dated period start).

`maintainConfigHistoryOnEdit` stops wiping — it stamps the current period's rows with the **old** cadence and writes a version **effective tomorrow** carrying the new cadence + budget + categories.

`splitPeriodIntoSegments` prices a segment by **daily rate** (`toDailyRateCents × segDays`) only when the segment is *partial* **and** its config row carries a `reset_frequency`. Every budget/category-only edit — rows with `reset_frequency = NULL` — keeps today's whole-period proration **byte-for-byte**.

## Schema / export

- **v45**: `tracker_config_history.reset_frequency TEXT` (nullable). `NULL` = "the period's own cadence", correct for every existing row → **no backfill**.
- `writeTrackerConfigVersion` gains an optional trailing `resetFrequency` arg; all other callers unchanged.
- Profile export **payload v7**: `trackerConfigHistory` rows carry `reset_frequency`; pre-v7 rows import as `NULL`.

## Tests

Pure-core daily-rate pricing + a NULL-regression guard + the full-period-tag guard; `updateTracker` transitional path (start preserved, timeline kept, old/new cadence stamped); reset-day-only change; broken-data fallback; v45 migration (column added, existing rows NULL, idempotent); `trackerConfigHistory` export→import round-trip of `reset_frequency` + pre-v7 → NULL.

575 unit tests green · `npm run validate` + `npm run build` clean.

Docs (`docs/` gitignored): `ADR-0014`, `trackers/OVERVIEW.md`, `DATABASE.md` — to apply on approval. `CHANGELOG.md` in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)