### PR TITLE
Trackers: show how the last completed period ended vs budget (#17)

### DIFF
--- a/src/pages/analytics/AnalyticsTrackersDetail.tsx
+++ b/src/pages/analytics/AnalyticsTrackersDetail.tsx
@@ -125,6 +125,17 @@ export function AnalyticsTrackersDetail() {
     [effectivePeriodHistory]
   )
 
+  // #17 — informational "came in under / over budget" for the most recently
+  // completed period. Only when there was real spend, so a pre-creation
+  // fabricated period can't read as a $0-spend "win".
+  const lastCompletedPeriod = useMemo(
+    () =>
+      effectivePeriodHistory.find(
+        (p) => p.periodOffset === -1 && p.spent > 0
+      ) ?? null,
+    [effectivePeriodHistory]
+  )
+
   // Initialise date filter when period data loads; re-initialise when display period changes.
   useEffect(() => {
     if (currentPeriod && !periodInitialized.current) {
@@ -406,6 +417,37 @@ export function AnalyticsTrackersDetail() {
               <Card.Title className="mb-0">
                 Spend vs Budget by Period
               </Card.Title>
+              {lastCompletedPeriod && (
+                <Card.Text
+                  as="div"
+                  className={`small mt-1 ${
+                    lastCompletedPeriod.spent < lastCompletedPeriod.budget
+                      ? 'text-success'
+                      : 'text-muted'
+                  }`}
+                >
+                  {lastCompletedPeriod.spent < lastCompletedPeriod.budget ? (
+                    <>
+                      <i className="mdi mdi-trophy-outline me-1" aria-hidden />
+                      {lastCompletedPeriod.periodLabel}: came in $
+                      {formatMoney(
+                        lastCompletedPeriod.budget - lastCompletedPeriod.spent
+                      )}{' '}
+                      under budget
+                    </>
+                  ) : lastCompletedPeriod.spent > lastCompletedPeriod.budget ? (
+                    <>
+                      {lastCompletedPeriod.periodLabel}: $
+                      {formatMoney(
+                        lastCompletedPeriod.spent - lastCompletedPeriod.budget
+                      )}{' '}
+                      over budget
+                    </>
+                  ) : (
+                    <>{lastCompletedPeriod.periodLabel}: exactly on budget</>
+                  )}
+                </Card.Text>
+              )}
               <Form.Select
                 value={periodsBack}
                 onChange={(e) => setPeriodsBack(Number(e.target.value))}

--- a/src/services/trackerConfigHistory.test.ts
+++ b/src/services/trackerConfigHistory.test.ts
@@ -30,6 +30,7 @@ const {
   getTrackerConfigHistory,
   getTrackersWithProgress,
   getTrackerTransactionsInPeriod,
+  getTrackerPeriodHistory,
 } = await import('./trackers')
 const { buildExportPayload, replaceTrackers } = await import('./profileExport')
 const { localDateString } = await import('@/lib/format')
@@ -423,6 +424,37 @@ describe('computeCurrentPeriodSegments (DB wrapper)', () => {
     expect(segs.reduce((s, seg) => s + seg.spent, 0)).toBe(4000)
     expect(segs[0].budget).toBe(Math.round((30000 * 4) / 7))
     expect(segs[1].budget).toBe(Math.round((40000 * 3) / 7))
+  })
+})
+
+describe('getTrackerPeriodHistory — completed-period result (#17)', () => {
+  it('reports a previous period as under budget by budget − spent', () => {
+    const id = createTracker('Food', 30000, 'WEEKLY', 1, ['groceries'])
+    // current week 9–16 Mar → previous week is 2–9 Mar
+    setPeriod(id, '2026-03-09', '2026-03-16')
+    insertTx('p1', 'groceries', -8000, '2026-03-03')
+    insertTx('p2', 'groceries', -4000, '2026-03-05')
+
+    const prev = getTrackerPeriodHistory(id, 3).find(
+      (p) => p.periodOffset === -1
+    )!
+    expect(prev.spent).toBe(12000)
+    expect(prev.budget).toBe(30000) // head budget, per ADR-0014 (past periods)
+    expect(prev.remaining).toBe(18000) // "came in $180 under"
+    expect(prev.spent < prev.budget).toBe(true)
+  })
+
+  it('reports a previous period as over budget (spent >= budget, remaining floored at 0)', () => {
+    const id = createTracker('Food', 10000, 'WEEKLY', 1, ['groceries'])
+    setPeriod(id, '2026-03-09', '2026-03-16')
+    insertTx('o1', 'groceries', -15000, '2026-03-04')
+
+    const prev = getTrackerPeriodHistory(id, 3).find(
+      (p) => p.periodOffset === -1
+    )!
+    expect(prev.spent).toBe(15000)
+    expect(prev.remaining).toBe(0)
+    expect(prev.spent > prev.budget).toBe(true)
   })
 })
 


### PR DESCRIPTION
Closes #17.

**Decision (with Okky): informational only** — no unused-budget rollover, no touch to the Spendable / `effectiveBudget` calc.

On the tracker detail page, the **"Spend vs Budget by Period"** card gets a one-line subtitle for the most recently completed period:

- `🏆 Previous: came in $87.50 under budget` (green) when spend beat the budget
- `Previous: $23.00 over budget` (muted) otherwise
- shown **only when that period had real spend**, so a pre-creation fabricated period can't read as a `$0`-spend "win"

It reads the `effectivePeriodHistory` row the page already computes (`periodOffset === -1`) — **no new service code, no new queries**. Past periods use the head budget, per ADR-0014.

The card-level "quick glance" surfaces (Dashboard `TrackersSection`, Analytics tracker list) were left alone — they go through the period-offset + display-period-toggle path, more surface for a low-priority informational add. Easy follow-up if wanted.

Tests: `getTrackerPeriodHistory` reports a previous period as under / over budget with the right `spent` / `budget` / floored `remaining`. 577 unit tests green, `validate` + `build` clean.

Docs (`docs/` gitignored): a line in `trackers/OVERVIEW.md` — to apply on approval.

🤖 Generated with [Claude Code](https://claude.com/claude-code)