### PR TITLE
Passphrase: 12-char export minimum (#32) + Change passphrase action (#33)

### DIFF
--- a/src/lib/crypto.test.ts
+++ b/src/lib/crypto.test.ts
@@ -4,6 +4,8 @@ import {
   deriveKeyFromPassphrase,
   encryptToken,
   decryptToken,
+  reEncryptSecret,
+  PASSPHRASE_MIN_LENGTH,
 } from './crypto'
 
 describe('crypto', () => {
@@ -44,5 +46,48 @@ describe('crypto', () => {
     const salt = generateSalt()
     const key = await deriveKeyFromPassphrase('secret', salt, 1000)
     await expect(decryptToken(btoa('short'), key)).rejects.toThrow('too short')
+  })
+
+  describe('reEncryptSecret (#33)', () => {
+    const ITER = 1000
+    const CURRENT = 'current-passphrase-abc'
+    const NEXT = 'a-fresh-longer-passphrase'
+    const TOKEN = 'up:pat:secret-token-xyz'
+
+    async function seedCiphertext(): Promise<{ salt: string; ct: string }> {
+      const salt = generateSalt()
+      const key = await deriveKeyFromPassphrase(CURRENT, salt, ITER)
+      return { salt, ct: await encryptToken(TOKEN, key) }
+    }
+
+    it('re-encrypts under a new passphrase + fresh salt, recovering the plaintext', async () => {
+      const { salt, ct } = await seedCiphertext()
+      const res = await reEncryptSecret(ct, salt, CURRENT, NEXT, ITER)
+
+      expect(res.plaintext).toBe(TOKEN)
+      expect(res.salt).not.toBe(salt)
+
+      // New ciphertext opens with the new passphrase…
+      const newKey = await deriveKeyFromPassphrase(NEXT, res.salt, ITER)
+      expect(await decryptToken(res.ciphertext, newKey)).toBe(TOKEN)
+      // …and not with the old one.
+      const oldKey = await deriveKeyFromPassphrase(CURRENT, res.salt, ITER)
+      await expect(decryptToken(res.ciphertext, oldKey)).rejects.toThrow()
+    })
+
+    it('throws when the current passphrase is wrong', async () => {
+      const { salt, ct } = await seedCiphertext()
+      await expect(
+        reEncryptSecret(ct, salt, 'wrong-passphrase', NEXT, ITER)
+      ).rejects.toThrow()
+    })
+
+    it('throws when the new passphrase is shorter than the minimum', async () => {
+      const { salt, ct } = await seedCiphertext()
+      const short = 'x'.repeat(PASSPHRASE_MIN_LENGTH - 1)
+      await expect(
+        reEncryptSecret(ct, salt, CURRENT, short, ITER)
+      ).rejects.toThrow(/at least/)
+    })
   })
 })

--- a/src/lib/crypto.ts
+++ b/src/lib/crypto.ts
@@ -8,6 +8,13 @@ import { bufferToBase64, base64ToBuffer } from './base64'
 
 const PBKDF2_ITERATIONS = 100_000
 const KEY_LENGTH_BITS = 256
+
+/**
+ * Minimum length for any user-chosen passphrase — the unlock passphrase
+ * (`Onboarding`, `SecuritySection`) and the profile-export passphrase
+ * (`ExportProfileModal`). No composition rules (NIST SP 800-63B).
+ */
+export const PASSPHRASE_MIN_LENGTH = 12
 const SALT_LENGTH_BYTES = 16
 const IV_LENGTH_BYTES = 12
 const AES_GCM_TAG_LENGTH_BITS = 128
@@ -100,6 +107,38 @@ export async function decryptToken(
     ciphertext
   )
   return new TextDecoder().decode(decrypted)
+}
+
+/**
+ * Re-encrypt a stored secret under a new passphrase and a fresh salt. Decrypts
+ * with the current passphrase first, so a wrong current passphrase throws (this
+ * is how the "Change passphrase" flow verifies it) and there is no new attack
+ * surface. Returns the values to persist plus the recovered plaintext (so the
+ * caller can refresh any session cache). Throws if `newPassphrase` is shorter
+ * than `PASSPHRASE_MIN_LENGTH`.
+ */
+export async function reEncryptSecret(
+  ciphertextBase64: string,
+  currentSaltBase64: string,
+  currentPassphrase: string,
+  newPassphrase: string,
+  iterations: number = PBKDF2_ITERATIONS
+): Promise<{ salt: string; ciphertext: string; plaintext: string }> {
+  if (newPassphrase.length < PASSPHRASE_MIN_LENGTH) {
+    throw new Error(
+      `Passphrase must be at least ${PASSPHRASE_MIN_LENGTH} characters.`
+    )
+  }
+  const currentKey = await deriveKeyFromPassphrase(
+    currentPassphrase,
+    currentSaltBase64,
+    iterations
+  )
+  const plaintext = await decryptToken(ciphertextBase64, currentKey)
+  const salt = generateSalt()
+  const newKey = await deriveKeyFromPassphrase(newPassphrase, salt, iterations)
+  const ciphertext = await encryptToken(plaintext, newKey)
+  return { salt, ciphertext, plaintext }
 }
 
 export { PBKDF2_ITERATIONS }

--- a/src/pages/Onboarding.tsx
+++ b/src/pages/Onboarding.tsx
@@ -8,6 +8,7 @@ import {
   generateSalt,
   deriveKeyFromPassphrase,
   encryptToken,
+  PASSPHRASE_MIN_LENGTH,
 } from '@/lib/crypto'
 import { validateUpBankToken } from '@/api/upBank'
 import { performInitialSync, type SyncProgress } from '@/services/sync'
@@ -36,8 +37,10 @@ export function Onboarding({ onComplete }: OnboardingProps) {
   async function handleStep2Submit(e: FormEvent) {
     e.preventDefault()
     setError(null)
-    if (passphrase.length < 12) {
-      setError('Passphrase must be at least 12 characters.')
+    if (passphrase.length < PASSPHRASE_MIN_LENGTH) {
+      setError(
+        `Passphrase must be at least ${PASSPHRASE_MIN_LENGTH} characters.`
+      )
       return
     }
     if (passphrase !== passphraseConfirm) {
@@ -256,9 +259,9 @@ export function Onboarding({ onComplete }: OnboardingProps) {
                   type="password"
                   value={passphrase}
                   onChange={(e) => setPassphrase(e.target.value)}
-                  placeholder="At least 12 characters"
+                  placeholder={`At least ${PASSPHRASE_MIN_LENGTH} characters`}
                   autoComplete="new-password"
-                  minLength={12}
+                  minLength={PASSPHRASE_MIN_LENGTH}
                 />
               </Form.Group>
               <Form.Group className="mb-3">

--- a/src/pages/settings/ExportProfileModal.tsx
+++ b/src/pages/settings/ExportProfileModal.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react'
 import { Button, Modal, Form, Spinner } from 'react-bootstrap'
 import { toast } from '@/stores/toastStore'
 import { exportProfile } from '@/services/profileExport'
+import { PASSPHRASE_MIN_LENGTH } from '@/lib/crypto'
 
 export function ExportProfileModal() {
   const [show, setShow] = useState(false)
@@ -26,6 +27,12 @@ export function ExportProfileModal() {
     const confirmVal = passphraseConfirm.trim()
     if (!trimmed) {
       setError('Please enter a passphrase.')
+      return
+    }
+    if (trimmed.length < PASSPHRASE_MIN_LENGTH) {
+      setError(
+        `Passphrase must be at least ${PASSPHRASE_MIN_LENGTH} characters.`
+      )
       return
     }
     if (trimmed !== confirmVal) {
@@ -96,8 +103,9 @@ export function ExportProfileModal() {
                 type="password"
                 value={passphrase}
                 onChange={(e) => setPassphrase(e.target.value)}
-                placeholder="Enter passphrase"
+                placeholder={`At least ${PASSPHRASE_MIN_LENGTH} characters`}
                 autoComplete="new-password"
+                minLength={PASSPHRASE_MIN_LENGTH}
                 disabled={exporting}
               />
             </Form.Group>

--- a/src/pages/settings/PassphraseChangeModal.tsx
+++ b/src/pages/settings/PassphraseChangeModal.tsx
@@ -1,0 +1,202 @@
+import { useState } from 'react'
+import { Button, Modal, Form, Spinner } from 'react-bootstrap'
+import { getAppSetting, setAppSetting } from '@/db'
+import { toast } from '@/stores/toastStore'
+import { reEncryptSecret, PASSPHRASE_MIN_LENGTH } from '@/lib/crypto'
+import {
+  storeBiometricSession,
+  hasBiometricSession,
+} from '@/lib/biometricSession'
+
+/**
+ * #33 — change the unlock passphrase. Mirrors the Personal Access Token update:
+ * it requires the *current* passphrase (decrypting the stored token verifies
+ * it), so there is no new attack surface. No "forgot passphrase" path — that is
+ * still Clear-all-data by design.
+ */
+export function PassphraseChangeModal() {
+  const [show, setShow] = useState(false)
+  const [current, setCurrent] = useState('')
+  const [next, setNext] = useState('')
+  const [confirm, setConfirm] = useState('')
+  const [error, setError] = useState<string | null>(null)
+  const [loading, setLoading] = useState(false)
+
+  function close() {
+    if (loading) return
+    setShow(false)
+    setCurrent('')
+    setNext('')
+    setConfirm('')
+    setError(null)
+  }
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    setError(null)
+    if (!current || !next) {
+      setError('Please fill in every field.')
+      return
+    }
+    if (next.length < PASSPHRASE_MIN_LENGTH) {
+      setError(
+        `New passphrase must be at least ${PASSPHRASE_MIN_LENGTH} characters.`
+      )
+      return
+    }
+    if (next !== confirm) {
+      setError('New passphrases do not match.')
+      return
+    }
+    if (next === current) {
+      setError('New passphrase must be different from the current one.')
+      return
+    }
+
+    const salt = getAppSetting('encryption_salt')
+    const encrypted = getAppSetting('api_token_encrypted')
+    if (!salt || !encrypted) {
+      setError('No stored credentials. Please complete onboarding first.')
+      return
+    }
+
+    setLoading(true)
+    try {
+      const {
+        salt: newSalt,
+        ciphertext: newEncrypted,
+        plaintext: token,
+      } = await reEncryptSecret(encrypted, salt, current, next)
+      setAppSetting('encryption_salt', newSalt)
+      setAppSetting('api_token_encrypted', newEncrypted)
+      // Re-cache the biometric session so a later fingerprint unlock isn't tied
+      // to state derived from the old passphrase.
+      if (hasBiometricSession()) await storeBiometricSession(token)
+      toast.success('Passphrase changed.')
+      close()
+    } catch {
+      // A wrong current passphrase surfaces here as an AES-GCM decrypt failure.
+      setError(
+        'Could not change passphrase — check that your current passphrase is correct.'
+      )
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <div className="mb-4">
+      <h6 className="text-muted mb-2">Passphrase</h6>
+      <p className="small text-muted mb-2">
+        Change the passphrase that unlocks Vantura. You&apos;ll need your
+        current one. There is no recovery if you forget it — Clear all data is
+        the only way back.
+      </p>
+      <Button
+        variant="outline-secondary"
+        size="sm"
+        onClick={() => {
+          setError(null)
+          setShow(true)
+        }}
+        aria-label="Change passphrase"
+      >
+        Change passphrase
+      </Button>
+
+      <Modal
+        show={show}
+        onHide={close}
+        aria-labelledby="change-passphrase-modal-title"
+        centered
+      >
+        <Modal.Header closeButton={!loading}>
+          <Modal.Title id="change-passphrase-modal-title">
+            Change passphrase
+          </Modal.Title>
+        </Modal.Header>
+        <Form onSubmit={handleSubmit}>
+          <Modal.Body>
+            <Form.Group className="mb-3">
+              <Form.Label htmlFor="change-passphrase-current">
+                Current passphrase
+              </Form.Label>
+              <Form.Control
+                id="change-passphrase-current"
+                type="password"
+                value={current}
+                onChange={(e) => setCurrent(e.target.value)}
+                autoComplete="current-password"
+                disabled={loading}
+              />
+            </Form.Group>
+            <Form.Group className="mb-3">
+              <Form.Label htmlFor="change-passphrase-new">
+                New passphrase
+              </Form.Label>
+              <Form.Control
+                id="change-passphrase-new"
+                type="password"
+                value={next}
+                onChange={(e) => setNext(e.target.value)}
+                placeholder={`At least ${PASSPHRASE_MIN_LENGTH} characters`}
+                autoComplete="new-password"
+                minLength={PASSPHRASE_MIN_LENGTH}
+                disabled={loading}
+              />
+            </Form.Group>
+            <Form.Group className="mb-3">
+              <Form.Label htmlFor="change-passphrase-confirm">
+                Confirm new passphrase
+              </Form.Label>
+              <Form.Control
+                id="change-passphrase-confirm"
+                type="password"
+                value={confirm}
+                onChange={(e) => setConfirm(e.target.value)}
+                autoComplete="new-password"
+                disabled={loading}
+              />
+            </Form.Group>
+            {error && (
+              <div className="text-danger small mb-2" role="alert">
+                {error}
+              </div>
+            )}
+          </Modal.Body>
+          <Modal.Footer>
+            <Button
+              type="button"
+              variant="secondary"
+              onClick={close}
+              disabled={loading}
+            >
+              Cancel
+            </Button>
+            <Button
+              type="submit"
+              className="btn-gradient-primary"
+              disabled={loading}
+              aria-busy={loading}
+            >
+              {loading ? (
+                <>
+                  <Spinner
+                    animation="border"
+                    size="sm"
+                    className="me-1"
+                    role="status"
+                    aria-hidden="true"
+                  />
+                  Changing…
+                </>
+              ) : (
+                'Change passphrase'
+              )}
+            </Button>
+          </Modal.Footer>
+        </Form>
+      </Modal>
+    </div>
+  )
+}

--- a/src/pages/settings/SecuritySection.tsx
+++ b/src/pages/settings/SecuritySection.tsx
@@ -8,6 +8,7 @@ import {
   clearBiometricSession,
   storeBiometricSession,
 } from '@/lib/biometricSession'
+import { PassphraseChangeModal } from './PassphraseChangeModal'
 
 export function SecuritySection() {
   const [bioAvailable, setBioAvailable] = useState<boolean | null>(null)
@@ -113,6 +114,8 @@ export function SecuritySection() {
           <option value="30">30 minutes</option>
         </Form.Select>
       </Form.Group>
+      <hr className="mb-4" />
+      <PassphraseChangeModal />
       <hr className="mb-4" />
       {bioAvailable === null && (
         <div

--- a/src/services/profileExport.test.ts
+++ b/src/services/profileExport.test.ts
@@ -154,10 +154,16 @@ describe('profileExport', () => {
 
     it('decryptImportFile throws when appSchemaVersion exceeds current', async () => {
       const payload: ExportPayload = { ...EMPTY_PAYLOAD, appSchemaVersion: 99 }
-      const wrapper = await encryptExportPayload(payload, 'pass')
-      await expect(decryptImportFile(wrapper, 'pass')).rejects.toThrow(
-        /newer app version/
-      )
+      const wrapper = await encryptExportPayload(payload, 'pass-phrase-1234')
+      await expect(
+        decryptImportFile(wrapper, 'pass-phrase-1234')
+      ).rejects.toThrow(/newer app version/)
+    })
+
+    it('encryptExportPayload rejects a passphrase shorter than the minimum (#32)', async () => {
+      await expect(
+        encryptExportPayload(EMPTY_PAYLOAD, 'short')
+      ).rejects.toThrow(/at least/)
     })
   })
 
@@ -250,13 +256,13 @@ describe('profileExport', () => {
           },
         ],
       }
-      const wrapper = await encryptExportPayload(payload, 'secret')
+      const wrapper = await encryptExportPayload(payload, 'secret-phrase-123')
       const json = JSON.stringify(wrapper)
       const file = new File([json], 'test.json', {
         type: 'application/json',
       })
 
-      const result = await previewImportProfile(file, 'secret')
+      const result = await previewImportProfile(file, 'secret-phrase-123')
 
       expect(result.settings).toEqual(payload.settings)
       expect(result.trackers).toEqual([])
@@ -264,7 +270,10 @@ describe('profileExport', () => {
     })
 
     it('throws IMPORT_ERROR_WRONG_PASSPHRASE on wrong passphrase', async () => {
-      const wrapper = await encryptExportPayload(EMPTY_PAYLOAD, 'correct')
+      const wrapper = await encryptExportPayload(
+        EMPTY_PAYLOAD,
+        'correct-phrase-12'
+      )
       const file = new File([JSON.stringify(wrapper)], 'test.json', {
         type: 'application/json',
       })

--- a/src/services/profileExport.ts
+++ b/src/services/profileExport.ts
@@ -15,6 +15,7 @@ import {
   encryptToken,
   decryptToken,
   PBKDF2_ITERATIONS,
+  PASSPHRASE_MIN_LENGTH,
 } from '@/lib/crypto'
 import { SCHEMA_VERSION } from '@/db/schema'
 import { writeTrackerConfigVersion } from './trackers'
@@ -501,10 +502,16 @@ export function buildExportPayload(): ExportPayload {
 /**
  * Encrypt the payload with a passphrase and return the file wrapper.
  */
+/** User-facing error when the chosen export passphrase is too short (#32). */
+export const EXPORT_ERROR_PASSPHRASE_TOO_SHORT = `Passphrase must be at least ${PASSPHRASE_MIN_LENGTH} characters.`
+
 export async function encryptExportPayload(
   payload: ExportPayload,
   passphrase: string
 ): Promise<ExportFileWrapper> {
+  if (passphrase.length < PASSPHRASE_MIN_LENGTH) {
+    throw new Error(EXPORT_ERROR_PASSPHRASE_TOO_SHORT)
+  }
   const salt = generateSalt()
   const key = await deriveKeyFromPassphrase(passphrase, salt)
   const json = JSON.stringify(payload)


### PR DESCRIPTION
Closes #32, closes #33. Two small security items.

## #32 — profile-export passphrase minimum

Onboarding enforces 12 chars on the unlock passphrase; the export/import passphrase enforced nothing. **Decision (with Okky): same 12-char minimum, no composition rules** (NIST SP 800-63B).

- `PASSPHRASE_MIN_LENGTH = 12` constant in `crypto.ts`; `Onboarding.tsx` now uses it (was an inline `12`).
- `encryptExportPayload` **throws** below the minimum — no caller (modal, batch, a future CLI) can produce a weakly-encrypted file.
- `ExportProfileModal` validates client-side + `minLength` on the field.

## #33 — Change passphrase

**Settings → Security → Change passphrase.** Mirrors the "Update Personal Access Token" flow — it requires the *current* passphrase (decrypting the stored token verifies it), so **no new attack surface**. No "forgot passphrase, recover anyway" path — Clear-all-data stays the only way back, by design.

The re-key is a pure, unit-tested `reEncryptSecret(ciphertext, currentSalt, currentPassphrase, newPassphrase)` in `crypto.ts`: decrypt with the current key (verifies), generate a fresh salt, re-encrypt, return `{ salt, ciphertext, plaintext }`. The modal persists `encryption_salt` + `api_token_encrypted` and refreshes the biometric session cache with the recovered token. `Unlock.tsx` already reads the salt fresh each unlock, so the new passphrase works immediately.

## Tests

`reEncryptSecret`: round-trips + recovers the plaintext, new ciphertext opens with the new passphrase and not the old, throws on a wrong current passphrase, throws below the minimum. `encryptExportPayload` rejects a short passphrase. 581 unit tests green, `validate` + `build` clean.

Docs (`docs/` gitignored): `security-auth/OVERVIEW.md` + `CONTEXT.md` — to apply on approval.

🤖 Generated with [Claude Code](https://claude.com/claude-code)