### PR TITLE
Notifications: make the reminder ↔ due-soon-banner link legible (#22)

### DIFF
--- a/src/components/dashboard/UpcomingSection.tsx
+++ b/src/components/dashboard/UpcomingSection.tsx
@@ -1203,8 +1203,10 @@ export function UpcomingSection({
                     </Col>
                   </Row>
                   <Form.Text className="text-muted d-block mb-2">
-                    Reminder shows &quot;Due in N days&quot; when within the set
-                    days. Stop date removes the charge after that date.
+                    Reminder shows &quot;Due in N days&quot; on the Dashboard
+                    when within the set days — plus a notification, if Bill
+                    reminders are on in Settings &rarr; Notifications. Stop date
+                    removes the charge after that date.
                   </Form.Text>
 
                   <Form.Group className="mb-2">

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -260,27 +260,51 @@ export function Dashboard() {
     notificationStore.getState().refreshUnreadCount()
   }, [dueSoon])
 
+  const scrollToUpcoming = useCallback(() => {
+    const el = document.getElementById('dashboard-section-upcoming')
+    if (!el) return
+    el.scrollIntoView({ behavior: 'smooth', block: 'center' })
+    el.classList.add('dashboard-scroll-highlight')
+    setTimeout(() => el.classList.remove('dashboard-scroll-highlight'), 2000)
+  }, [])
+
   const dueSoonAlert = useMemo(() => {
     if (bannerDismissedToday || dueSoon.length === 0) return null
     return (
       <div
-        className="alert alert-warning d-flex align-items-center gap-2 py-2 mb-4"
+        className="alert alert-warning d-flex align-items-start gap-2 py-2 mb-4"
         role="alert"
       >
-        <i className="mdi mdi-bell-ring flex-shrink-0" aria-hidden />
-        <span className="flex-grow-1">
-          <strong>Due soon: </strong>
-          {dueSoon.map((c, i) => {
-            const days = daysUntilCharge(c.next_charge_date)
-            const dayText = days === 0 ? 'today' : `in ${days}d`
-            return (
-              <span key={c.id}>
-                {i > 0 && <span className="text-muted mx-2">·</span>}
-                {c.name} (${formatMoney(c.amount)}) — {dayText}
-              </span>
-            )
-          })}
-        </span>
+        <i
+          className="mdi mdi-bell-ring flex-shrink-0"
+          aria-hidden
+          style={{ lineHeight: 1.5 }}
+        />
+        <div className="flex-grow-1">
+          <div>
+            <strong>Due soon: </strong>
+            {dueSoon.map((c, i) => {
+              const days = daysUntilCharge(c.next_charge_date)
+              const dayText = days === 0 ? 'today' : `in ${days}d`
+              return (
+                <span key={c.id}>
+                  {i > 0 && <span className="text-muted mx-2">·</span>}
+                  {c.name} (${formatMoney(c.amount)}) — {dayText}
+                </span>
+              )
+            })}
+          </div>
+          <div className="small mt-1">
+            Reminders you set · each clears itself when the payment lands
+            <button
+              type="button"
+              className="btn btn-link btn-sm p-0 ms-2 align-baseline"
+              onClick={scrollToUpcoming}
+            >
+              Manage in Upcoming →
+            </button>
+          </div>
+        </div>
         <button
           type="button"
           className="btn-close btn-close-white ms-2 flex-shrink-0"
@@ -291,7 +315,7 @@ export function Dashboard() {
         />
       </div>
     )
-  }, [dueSoon, bannerDismissedToday, handleDismissBanner])
+  }, [dueSoon, bannerDismissedToday, handleDismissBanner, scrollToUpcoming])
 
   const openCustomiseModal = useCallback(() => {
     setDraftSizes(getDashboardSectionSizes())

--- a/src/pages/Onboarding.tsx
+++ b/src/pages/Onboarding.tsx
@@ -518,6 +518,11 @@ export function Onboarding({ onComplete }: OnboardingProps) {
                 and reports.
               </p>
               <p className="text-muted small mb-3">
+                Vantura can remind you about upcoming bills and alert you when
+                Spendable runs low — turn those on in Settings &rarr;
+                Notifications.
+              </p>
+              <p className="text-muted small mb-3">
                 New to Vantura? You can take a short dashboard tour or read the
                 <a
                   href={`${import.meta.env.BASE_URL}help`}


### PR DESCRIPTION
Closes #22. Design decided in [the #22 comment](https://github.com/ostafford/Vantura_v3/issues/22#issuecomment-5509464654).

The first two of #22's three gaps already shipped (`63e6ad1` create-modal settlement explainer, `2d681e8` "Set up in: <screen>" lines on every notification toggle). This closes the rest — copy-only, no new logic.

- **Dashboard due-soon banner** gains a second line — *"Reminders you set · each clears itself when the payment lands"* — plus a **"Manage in Upcoming →"** button that scrolls to the Upcoming section (reusing the existing `dashboard-scroll-highlight` pattern). Answers the two things a new user can't tell today: *why* it appeared, and that it's **self-clearing** (not something to dismiss every day).
- **Onboarding "All set" step** gains one sentence: *"Vantura can remind you about upcoming bills and alert you when Spendable runs low — turn those on in Settings → Notifications."* No dedicated step, no permission prompt.
- The **"Remind me (days before)"** field's helper text now notes the notification side, gated on the Bill reminders toggle.

594 unit tests green, `validate` + `build` clean.

Docs (`docs/` gitignored): a line in `upcoming-charges/OVERVIEW.md` — to apply on approval.

🤖 Generated with [Claude Code](https://claude.com/claude-code)