### PR TITLE
Weekly Insights: drop empty parent-category group headers (#31)

### DIFF
--- a/src/components/dashboard/InsightsSection.tsx
+++ b/src/components/dashboard/InsightsSection.tsx
@@ -69,11 +69,11 @@ export function InsightsSection({
     [weekRange]
   )
 
-  // Every section (including the 4 real parent groups when they have zero
-  // spend, Uncategorised, and Other) gets a header row — this keeps the
-  // group order fixed and every group boundary a real visual divider,
-  // which the categorical colour system's adjacency validation depends on
-  // (see colorSystem.ts and getWeeklyCategoryBreakdownGrouped's doc comment).
+  // Every section the data layer returns (real parent groups with spend,
+  // Uncategorised, Other) gets a header row before its bars — so each group
+  // boundary is a real visual divider and the groups that appear stay in the
+  // colour system's validated order. Empty parent groups are dropped upstream
+  // (#31); see colorSystem.ts and getWeeklyCategoryBreakdownGrouped's doc.
   const rows: InsightsChartRow[] = useMemo(
     () =>
       sections.flatMap((section) => {

--- a/src/services/insights.groupedBreakdown.test.ts
+++ b/src/services/insights.groupedBreakdown.test.ts
@@ -1,9 +1,9 @@
 /**
  * getWeeklyCategoryBreakdownGrouped is load-bearing for the categorical
  * colour system's validated adjacency guarantees (see colorSystem.ts): the
- * 4 real parent groups must always render in a fixed order, even when a
- * group has zero spend, and overflow past the individual-category cap must
- * fold into "Other" rather than growing the visible category count.
+ * real parent groups that have spend must render in a fixed order (empty
+ * groups are dropped — #31), and overflow past the individual-category cap
+ * must fold into "Other" rather than growing the visible category count.
  */
 import { describe, it, expect, vi, beforeAll, beforeEach } from 'vitest'
 import initSqlJs, { type Database, type SqlJsStatic } from 'sql.js'
@@ -71,22 +71,34 @@ describe('getWeeklyCategoryBreakdownGrouped', () => {
     endIso: '2026-08-09T23:59:59.999Z',
   }
 
-  it('always returns all 4 real parent groups, in the fixed validated order, even with zero spend', () => {
-    // Only Home has any spend this week — Transport, Good Life, Personal
-    // must still appear as empty sections, not be omitted, since omitting
-    // a middle group would let its neighbours become directly adjacent
-    // without the CVD-safety guarantee that assumes this fixed chain order.
+  it('omits real parent groups with zero spend (#31), keeping the rest in the fixed validated order', () => {
+    // Only Home and Good Life have spend this week — Transport and Personal
+    // must NOT appear at all (no empty header). The groups that remain stay
+    // a subsequence of the CVD-validated chain order, each still preceded by
+    // its own header, so no cross-family bars become directly adjacent.
     insertSpend('groceries', 5000)
+    insertSpend('hobbies', 3000)
 
     const sections = getWeeklyCategoryBreakdownGrouped(weekRange)
     const parentNames = sections
       .filter((s) => !s.isOther && s.parentId !== null)
       .map((s) => s.parentName)
 
-    expect(parentNames).toEqual(['Home', 'Transport', 'Good Life', 'Personal'])
+    expect(parentNames).toEqual(['Home', 'Good Life'])
+  })
 
-    const transportSection = sections.find((s) => s.parentName === 'Transport')
-    expect(transportSection?.rows).toEqual([])
+  it('keeps present groups in PARENT_DISPLAY_ORDER regardless of which group has more spend', () => {
+    // Good Life outspends Home, but Home still sorts first — group order is
+    // fixed, never by spend.
+    insertSpend('groceries', 1000)
+    insertSpend('hobbies', 9000)
+
+    const sections = getWeeklyCategoryBreakdownGrouped(weekRange)
+    const parentNames = sections
+      .filter((s) => !s.isOther && s.parentId !== null)
+      .map((s) => s.parentName)
+
+    expect(parentNames).toEqual(['Home', 'Good Life'])
   })
 
   it('sorts rows by spend within each group', () => {

--- a/src/services/insights.ts
+++ b/src/services/insights.ts
@@ -424,11 +424,14 @@ const MAX_INDIVIDUAL_CATEGORIES = 7
  * categorical colour system was validated against (src/lib/colorSystem.ts —
  * the 6 category-family hues were CVD-safety-checked as a specific ordered
  * chain: Home, Transport, Good Life [split A/B], Personal [split A/B]).
- * Changing this order, or letting group order vary by spend, breaks that
- * validation — two families that were only checked as chain-neighbours could
- * end up directly adjacent with no colour-safety guarantee. Matched by name
- * (Up Bank's parent category names), not id, since real ids aren't yet
- * wired into this codebase — see colorSystem.ts's CATEGORY_ID_TO_SLOT.
+ * The CVD-adjacency guarantee depends on this *order* being preserved, not on
+ * every group being present: a section that renders always emits its own
+ * header before its bars, so the groups that do appear stay a subsequence of
+ * the validated chain with a header buffer between each. Letting group order
+ * vary by spend would break it — two families only checked as chain-neighbours
+ * could end up directly adjacent. Matched by name (Up Bank's parent category
+ * names), not id, since real ids aren't yet wired into this codebase — see
+ * colorSystem.ts's CATEGORY_ID_TO_SLOT.
  */
 const PARENT_DISPLAY_ORDER = ['Home', 'Transport', 'Good Life', 'Personal']
 
@@ -436,10 +439,10 @@ const PARENT_DISPLAY_ORDER = ['Home', 'Transport', 'Good Life', 'Personal']
  * Weekly category spend, grouped by real parent category in a fixed order,
  * sorted by spend within each group, with everything past the top
  * MAX_INDIVIDUAL_CATEGORIES individual categories (by spend, across all
- * parents) folded into a single "Other" row. Every real parent group always
- * renders (even with zero rows) so the chart's group dividers stay in a
- * fixed sequence — required for the colour system's adjacency guarantees;
- * see PARENT_DISPLAY_ORDER above.
+ * parents) folded into a single "Other" row. Real parent groups with zero
+ * spend that week are omitted (see #31 — the colour system's adjacency
+ * guarantee needs the fixed *order* of the groups that appear, not an empty
+ * header for every group); PARENT_DISPLAY_ORDER above has the reasoning.
  */
 export function getWeeklyCategoryBreakdownGrouped(
   weekRange?: WeekRange
@@ -503,12 +506,17 @@ export function getWeeklyCategoryBreakdownGrouped(
       orderIndex(a.name) - orderIndex(b.name) || a.name.localeCompare(b.name)
   )
 
-  const sections: CategoryGroupSection[] = orderedParents.map((p) => ({
-    parentId: p.id,
-    parentName: p.name,
-    rows: rowsByParentId.get(p.id) ?? [],
-    isOther: false,
-  }))
+  const sections: CategoryGroupSection[] = orderedParents
+    .map((p) => ({
+      parentId: p.id,
+      parentName: p.name,
+      rows: rowsByParentId.get(p.id) ?? [],
+      isOther: false,
+    }))
+    // Drop real-parent groups with no spend this week (#31). The CVD-adjacency
+    // guarantee needs the remaining groups to stay in PARENT_DISPLAY_ORDER,
+    // which the sort above already ensures — not an empty header per group.
+    .filter((s) => s.rows.length > 0)
 
   if (uncategorisedRows.length > 0) {
     sections.push({


### PR DESCRIPTION
Closes #31.

## What

`getWeeklyCategoryBreakdownGrouped` emitted a section — and `InsightsBarChart` a header row + divider — for **every** real parent category (Home / Transport / Good Life / Personal) even when that parent had zero spend that week. Each empty header consumed a full `scaleBand` slot, wasting vertical space (an empty "Transport" header in a car-free week).

## CVD pass

The issue asked whether the categorical colour system's adjacency guarantee depends on the empty headers being present, or only on the order of the non-empty groups. It's the latter:

- **Bar colour is position-independent** — `getCategoryColor(category_id, mode)` resolves purely through `CATEGORY_ID_TO_SLOT` → `(family, index)` → ramp hex. No neighbour / header / chart-position input.
- **Every section emits its own header before its bars** (`sections.flatMap(s => [header, ...bars])`), so the first bar of any group is always preceded by that group's header. An *empty* header only ever appeared flanked by other headers — never between two coloured bars. It was pure whitespace, not a CVD buffer.
- After filtering empty groups, the survivors stay a **subsequence of the validated chain** `Home → Transport → Good Life[A/B] → Personal[A/B]` (the `PARENT_DISPLAY_ORDER` sort already guarantees order), each still carrying its own header divider. Within-family shade order is untouched.
- Degenerate cases hold: all-empty week still returns `[]` early; single non-empty group → one header + its bars, no cross-family adjacency.

## Changes

- `src/services/insights.ts` — `getWeeklyCategoryBreakdownGrouped` filters real-parent sections with no rows; reworked `PARENT_DISPLAY_ORDER` + function doc comments. Uncategorised / Other unchanged (already conditionally appended, neutral grey).
- `src/components/dashboard/InsightsSection.tsx` — updated the header-row comment.
- `src/services/insights.groupedBreakdown.test.ts` — replaced the "always returns all 4 parent groups even with zero spend" test with one asserting empty groups are omitted and survivors stay in `PARENT_DISPLAY_ORDER`; added a spend-doesn't-reorder-groups test.
- Docs (gitignored): `docs/features/weekly-insights/OVERVIEW.md`, `docs/features/appearance-theme/OVERVIEW.md`, `docs/adr/0011-computed-colours-no-user-choice.md` updated to record the #31 outcome.

## Verification

- `npm run validate` clean.
- `src/services` suite (313 tests) + `colorSystem` tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)