### PR TITLE
Release v0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.9.0] - 2026-09-07
+
+First tagged release since the July stability audit (74 commits). Colour is now fully automatic and CVD-validated, Vantura can spot recurring charges in your history, Savers keep a goal history with per-cycle interest, and changing a tracker's cadence no longer discards the in-flight period. Plus the feature-polish batch from the docs rebuild (#13) and two accuracy fixes.
+
 ### Removed
 
 - **Colour is no longer user-configurable.** The six-swatch colour picker for tracker badges, Budget Plan buckets, and Weekly Insights categories is gone — every colour is now assigned automatically. Removes `src/lib/accentPalettes.ts`, `src/components/ChartColorPicker.tsx`, `src/components/CategoryColorsSection.tsx` (and the "Category colours" section in Settings → Appearance), and their storage (`trackers.badge_color`, `budget_buckets.colour`, `insights_category_colors` — dropped in schema v37).

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -249,6 +249,21 @@ Small enhancements to existing features, surfaced during the feature-by-feature 
 
 ---
 
+### v0.9.0 — Automatic Colour, Recurring Charges & Saver Goals — September 2026
+
+First release since the July audit (`v0.8.1`). Bundles the September feature-polish batch above with three larger features and two accuracy fixes.
+
+| Date | Feature |
+|------|---------|
+| Sep 7 | **`v0.9.0` released** — see [CHANGELOG](CHANGELOG.md#090---2026-09-07) for the full list |
+| — | **Automatic colour system** — the six-swatch colour picker is gone; every tracker, bucket, and category colour is derived from the entity's id and validated for colour-vision-deficiency safety (`src/lib/colorSystem.ts`, schema v37) |
+| — | **Recurring-charge detection** — "Find recurring charges" scans settled debits for steady-amount / steady-interval patterns and offers them as upcoming charges; never auto-added (schema v46, ADR-0016) |
+| — | **Saver goal history + interest** — reaching a goal records it and prompts the next; per-cycle and all-time interest earned shown per card (schema v44, ADR-0015) |
+| — | **Tracker cadence changes keep the in-flight period** — a frequency / reset-day change now writes a transitional period instead of wiping config history (schema v45, ADR-0014) |
+| — | **Fixed** — Net Worth projected balance undercounted recurring charges; tracker day-counts / period history used UTC instead of the local date |
+
+---
+
 ## Under Consideration
 
 Features that have been discussed or noted as potential future additions. Nothing here is committed.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vantura",
   "private": true,
-  "version": "0.8.1",
+  "version": "0.9.0",
   "type": "module",
   "scripts": {
     "prepare": "husky",

--- a/src/data/changelog.ts
+++ b/src/data/changelog.ts
@@ -24,6 +24,40 @@ export interface UpcomingItem {
 
 export const MILESTONES: Milestone[] = [
   {
+    date: '7 Sep 2026',
+    heading: 'Automatic Colour, Recurring Charges & Saver Goals',
+    icon: 'mdi-auto-fix',
+    primaryMonth: '2026-09',
+    version: '0.9.0',
+    color: '#a5d6a7',
+    items: [
+      {
+        icon: 'mdi-palette-outline',
+        text: 'Automatic colours — the colour picker for tracker badges, Budget Plan buckets, and Weekly Insights categories is gone. Every colour is now assigned for you and checked to stay distinguishable for colour-blind vision in both light and dark mode.',
+      },
+      {
+        icon: 'mdi-magnify-scan',
+        text: 'Find recurring charges — a new button in the Upcoming section scans your settled transactions for steady-amount, steady-interval patterns (Netflix, gym, insurance…) and offers them as upcoming charges. Nothing is added automatically, and a "Not recurring" dismissal is remembered.',
+      },
+      {
+        icon: 'mdi-flag-checkered',
+        text: 'Saver goal history — reaching a goal now records it and lets you set the next one, with past goals and the date each was reached listed on the card. Interest earned is shown per goal cycle and all-time.',
+      },
+      {
+        icon: 'mdi-calendar-sync-outline',
+        text: "Changing a tracker's frequency or reset day no longer throws away the current period — it keeps its start, runs to the new cadence's next reset, and the new setup takes effect the next day.",
+      },
+      {
+        icon: 'mdi-chart-timeline-variant',
+        text: 'Weekly Insights now groups spending categories under their real Up Bank parent (Home, Transport, Good Life, Personal) in a fixed order.',
+      },
+      {
+        icon: 'mdi-bug-check-outline',
+        text: "Fixes — the Net Worth card's projected balance no longer undercounts repeating charges, and tracker day-counts and period history now use your local date instead of UTC.",
+      },
+    ],
+  },
+  {
     date: '30 Jul 2026',
     heading: 'Stability & Accuracy Audit',
     icon: 'mdi-shield-check-outline',


### PR DESCRIPTION
First tagged release since the July stability audit — **74 commits since `v0.8.1`** (2026-07-30).

## What this PR does

Release bookkeeping only; every feature/fix below already landed on `main` via its own PR.

- `package.json` `0.8.1` → `0.9.0` (feeds `__APP_VERSION__`)
- `CHANGELOG.md` — `[Unreleased]` promoted to `## [0.9.0] - 2026-09-07` with a summary paragraph; fresh empty `[Unreleased]`
- `ROADMAP.md` — new **"v0.9.0 — Automatic Colour, Recurring Charges & Saver Goals — September 2026"** section
- `src/data/changelog.ts` — new `MILESTONES` entry (`version: '0.9.0'`) that drives the in-app What's New modal and `/changelog`

## Headline changes in 0.9.0

- **Automatic colour system** — colour picker removed; every tracker/bucket/category colour derived from its id and CVD-validated (schema v37)
- **Recurring-charge detection** — "Find recurring charges" scans settled debits; never auto-adds (schema v46, ADR-0016)
- **Saver goal history + per-cycle interest** (schema v44, ADR-0015)
- **Tracker cadence changes keep the in-flight period** — transitional period instead of wiping config history (schema v45, ADR-0014)
- **Weekly Insights** grouped by Up Bank parent category
- **Fixes** — Net Worth projected balance undercounted recurring charges; tracker day-counts / period history used UTC not local date

## Verification

- `npm run validate` — clean (3 pre-existing warnings only)
- `npx vitest run` — 595 passed / 46 files

## After merge

Tag `v0.9.0` on the merge commit and push the tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)