### PR TITLE
Dashboard: Spendable-hero balance zone (#15)

### DIFF
--- a/src/components/dashboard/BalanceCards.tsx
+++ b/src/components/dashboard/BalanceCards.tsx
@@ -1,0 +1,140 @@
+import type { ReactNode } from 'react'
+import { OverlayTrigger, Tooltip } from 'react-bootstrap'
+
+/**
+ * The Dashboard's balance zone: Spendable as a full-width hero, with Available
+ * and Forecast demoted to two supporting mini-tiles beside it (ticket #15).
+ * Spendable is the safety-net "source of truth" (docs/PRODUCT.md), so it owns
+ * the visual hierarchy here rather than sitting in a row of three equal cards.
+ *
+ * All values arrive pre-formatted from Dashboard.tsx — this component is
+ * presentation only. `tone` drives the semantic colour: Spendable turns
+ * `danger` when negative or below the low-balance alert threshold; Forecast
+ * turns `danger` when negative.
+ */
+
+type HeroTone = 'success' | 'danger'
+type TileTone = 'success' | 'info' | 'danger'
+
+interface BalanceCardsProps {
+  spendableValue: ReactNode
+  spendableSubtitle: ReactNode
+  spendableTone: HeroTone
+  spendableTooltip: ReactNode
+  onOpenAlert: () => void
+  availableValue: ReactNode
+  availableSubtitle: ReactNode
+  availableTooltip: ReactNode
+  forecastValue: ReactNode
+  forecastSubtitle: ReactNode
+  forecastTone: TileTone
+  forecastTooltip: ReactNode
+}
+
+function InfoTip({ id, tooltip }: { id: string; tooltip: ReactNode }) {
+  return (
+    <OverlayTrigger
+      placement="top"
+      trigger={['hover', 'focus', 'click']}
+      rootClose
+      overlay={
+        <Tooltip id={`balance-${id}-tooltip`} className="tooltip-rich">
+          {tooltip}
+        </Tooltip>
+      }
+    >
+      <span
+        className="balance-info"
+        role="img"
+        aria-label={`How ${id} is calculated`}
+        onClick={(e) => e.stopPropagation()}
+      >
+        <i className="mdi mdi-information-outline" aria-hidden />
+      </span>
+    </OverlayTrigger>
+  )
+}
+
+function MiniTile({
+  name,
+  tone,
+  value,
+  subtitle,
+  tooltip,
+}: {
+  name: string
+  tone: TileTone
+  value: ReactNode
+  subtitle: ReactNode
+  tooltip: ReactNode
+}) {
+  return (
+    <div className={`balance-tile balance-tile--${tone}`}>
+      <div className="balance-tile__label">
+        <span className="balance-tile__dot" aria-hidden />
+        {name}
+        <InfoTip id={name.toLowerCase()} tooltip={tooltip} />
+      </div>
+      <div className="balance-tile__value">{value}</div>
+      {subtitle && <div className="balance-tile__subtitle">{subtitle}</div>}
+    </div>
+  )
+}
+
+export function BalanceCards({
+  spendableValue,
+  spendableSubtitle,
+  spendableTone,
+  spendableTooltip,
+  onOpenAlert,
+  availableValue,
+  availableSubtitle,
+  availableTooltip,
+  forecastValue,
+  forecastSubtitle,
+  forecastTone,
+  forecastTooltip,
+}: BalanceCardsProps) {
+  return (
+    <div className="balance-cards mb-4" data-tour="balance-cards">
+      <div
+        id="dashboard-spendable-card"
+        className={`balance-hero balance-hero--${spendableTone}`}
+        role="button"
+        tabIndex={0}
+        onClick={onOpenAlert}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault()
+            onOpenAlert()
+          }
+        }}
+        aria-label="Spendable balance; click to set low balance alert"
+      >
+        <div className="balance-hero__label">
+          Spendable
+          <InfoTip id="spendable" tooltip={spendableTooltip} />
+        </div>
+        <div className="balance-hero__value">{spendableValue}</div>
+        <div className="balance-hero__subtitle">{spendableSubtitle}</div>
+      </div>
+
+      <div className="balance-tiles">
+        <MiniTile
+          name="Available"
+          tone="success"
+          value={availableValue}
+          subtitle={availableSubtitle}
+          tooltip={availableTooltip}
+        />
+        <MiniTile
+          name="Forecast"
+          tone={forecastTone}
+          value={forecastValue}
+          subtitle={forecastSubtitle}
+          tooltip={forecastTooltip}
+        />
+      </div>
+    </div>
+  )
+}

--- a/src/index.css
+++ b/src/index.css
@@ -1071,6 +1071,156 @@ a:not(.btn):not(.nav-link):not(.dropdown-item):hover {
   color: rgba(26, 26, 46, 0.82);
 }
 
+/* Balance zone (ticket #15): Spendable hero + Available / Forecast mini-tiles.
+   Spendable is the safety-net source of truth, so it owns the hierarchy; the
+   tiles are supporting reference values, not equal peers. */
+.balance-cards {
+  display: grid;
+  grid-template-columns: 2fr 1fr;
+  gap: 1rem;
+  align-items: stretch;
+}
+@media (max-width: 991.98px) {
+  .balance-cards {
+    grid-template-columns: 1fr;
+  }
+}
+
+.balance-hero {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  gap: 0.4rem;
+  padding: 1.5rem 1.75rem;
+  border: 1px solid var(--vantura-border);
+  border-left: 3px solid var(--vantura-success);
+  border-radius: 14px;
+  background: var(--vantura-surface);
+  color: var(--vantura-text);
+  cursor: pointer;
+  transition:
+    box-shadow var(--duration-fast) ease,
+    background-color var(--duration-fast) ease,
+    border-color var(--duration-fast) ease;
+}
+.balance-hero--danger {
+  border-left-color: var(--vantura-danger);
+  background: color-mix(
+    in srgb,
+    var(--vantura-surface) 92%,
+    var(--vantura-danger)
+  );
+}
+@media (hover: hover) and (pointer: fine) {
+  .balance-hero:hover {
+    box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
+  }
+}
+.balance-hero:active {
+  background: color-mix(
+    in srgb,
+    var(--vantura-surface) 94%,
+    var(--vantura-text)
+  );
+}
+.balance-hero--danger:active {
+  background: color-mix(
+    in srgb,
+    var(--vantura-surface) 86%,
+    var(--vantura-danger)
+  );
+}
+.balance-hero:focus-visible {
+  outline: 2px solid var(--vantura-primary);
+  outline-offset: 2px;
+}
+.balance-hero__label {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  font-size: 0.72rem;
+  font-weight: 500;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--vantura-text-secondary);
+}
+.balance-hero__value {
+  font-size: 2.4rem;
+  font-weight: 700;
+  line-height: 1.15;
+  letter-spacing: -0.02em;
+  font-variant-numeric: tabular-nums;
+}
+.balance-hero--danger .balance-hero__value {
+  color: var(--vantura-danger);
+}
+.balance-hero__subtitle {
+  font-size: 0.82rem;
+  color: var(--vantura-text-secondary);
+}
+
+.balance-tiles {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+.balance-tile {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  gap: 0.2rem;
+  flex: 1;
+  padding: 0.85rem 1rem;
+  border: 1px solid var(--vantura-border);
+  border-radius: 12px;
+  background: transparent;
+}
+.balance-tile__label {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  font-size: 0.68rem;
+  font-weight: 500;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--vantura-text-secondary);
+}
+.balance-tile__dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--vantura-success);
+  flex-shrink: 0;
+}
+.balance-tile--info .balance-tile__dot {
+  background: var(--vantura-info);
+}
+.balance-tile--danger .balance-tile__dot {
+  background: var(--vantura-danger);
+}
+.balance-tile__value {
+  font-size: 1.15rem;
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+}
+.balance-tile--danger .balance-tile__value {
+  color: var(--vantura-danger);
+}
+.balance-tile__subtitle {
+  font-size: 0.68rem;
+  color: var(--vantura-text-secondary);
+}
+
+.balance-info {
+  display: inline-flex;
+  cursor: help;
+  color: var(--vantura-text-secondary);
+  font-size: 0.85rem;
+}
+.balance-tile .balance-info {
+  font-size: 0.8rem;
+}
+
 /* Flat stat card (Monarch-inspired) */
 .stat-card-flat {
   border: 0;

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -1,6 +1,6 @@
 import { useState, useCallback, useMemo, useEffect } from 'react'
 import type React from 'react'
-import { Row, Col, Modal, Button, Form } from 'react-bootstrap'
+import { Modal, Button, Form } from 'react-bootstrap'
 import { useLocation } from 'react-router-dom'
 import { useStore } from 'zustand'
 import {
@@ -23,7 +23,7 @@ import { TrackersSection } from '@/components/dashboard/TrackersSection'
 import { UpcomingSection } from '@/components/dashboard/UpcomingSection'
 import { MonthSummarySection } from '@/components/dashboard/MonthSummarySection'
 import { NetWorthCard } from '@/components/dashboard/NetWorthCard'
-import { StatCard } from '@/components/StatCard'
+import { BalanceCards } from '@/components/dashboard/BalanceCards'
 import {
   shouldShowDashboardTour,
   startDashboardTour,
@@ -242,6 +242,32 @@ export function Dashboard() {
       </div>
     )
   })()
+
+  const availableTooltip = (
+    <div style={{ fontSize: '0.82rem' }}>
+      <div style={{ fontWeight: 600, marginBottom: '0.45rem' }}>
+        Your Up Bank balance
+      </div>
+      <div style={{ display: 'flex', flexDirection: 'column', gap: '0.25rem' }}>
+        <div>• Sum of all transactional account balances</div>
+        <div>• Excludes saver accounts</div>
+        <div>• Pending/held transactions already reflected</div>
+      </div>
+      {payAmountCents != null && (
+        <div
+          style={{
+            marginTop: '0.45rem',
+            borderTop: '1px solid rgba(255,255,255,0.12)',
+            paddingTop: '0.3rem',
+          }}
+        >
+          Post-payday: ${formatMoney(availableCents)} + $
+          {formatMoney(payAmountCents)} ={' '}
+          <strong>${formatMoney(availableCents + payAmountCents)}</strong>
+        </div>
+      )}
+    </div>
+  )
 
   const now = new Date()
   const headerDate = `${MONTH_NAMES[now.getMonth()]} ${now.getFullYear()}`
@@ -620,83 +646,22 @@ export function Dashboard() {
           </button>
         </div>
       </div>
-      <Row className="g-3 mb-4" data-tour="balance-cards">
-        <Col md={4} className="stretch-card">
-          <StatCard
-            title="Available"
-            value={availableCents}
-            subtitle={availableProjectedSubtitle}
-            gradient="success"
-            tooltip={
-              <div style={{ fontSize: '0.82rem' }}>
-                <div style={{ fontWeight: 600, marginBottom: '0.45rem' }}>
-                  Your Up Bank balance
-                </div>
-                <div
-                  style={{
-                    display: 'flex',
-                    flexDirection: 'column',
-                    gap: '0.25rem',
-                  }}
-                >
-                  <div>• Sum of all transactional account balances</div>
-                  <div>• Excludes saver accounts</div>
-                  <div>• Pending/held transactions already reflected</div>
-                </div>
-                {payAmountCents != null && (
-                  <div
-                    style={{
-                      marginTop: '0.45rem',
-                      borderTop: '1px solid rgba(255,255,255,0.12)',
-                      paddingTop: '0.3rem',
-                    }}
-                  >
-                    Post-payday: ${formatMoney(availableCents)} + $
-                    {formatMoney(payAmountCents)} ={' '}
-                    <strong>
-                      ${formatMoney(availableCents + payAmountCents)}
-                    </strong>
-                  </div>
-                )}
-              </div>
-            }
-          />
-        </Col>
-        <Col id="dashboard-spendable-card" md={4} className="stretch-card">
-          <div
-            role="button"
-            tabIndex={0}
-            onClick={openThresholdModal}
-            onKeyDown={(e) => {
-              if (e.key === 'Enter' || e.key === ' ') {
-                e.preventDefault()
-                openThresholdModal()
-              }
-            }}
-            style={{ cursor: 'pointer' }}
-            aria-label="Spendable balance; click to set low balance alert"
-          >
-            <StatCard
-              title="Spendable"
-              value={spendableCents}
-              displayValue={spendableDisplayValue}
-              subtitle={spendableSubtitle}
-              gradient={spendableGradient}
-              tooltip={spendableTooltip}
-            />
-          </div>
-        </Col>
-        <Col md={4} className="stretch-card">
-          <StatCard
-            title="Forecast"
-            value={forecastCents}
-            displayValue={forecastDisplayValue}
-            subtitle={forecastSubtitle}
-            gradient={forecastGradient}
-            tooltip={forecastTooltip}
-          />
-        </Col>
-      </Row>
+      <BalanceCards
+        spendableValue={
+          spendableDisplayValue ?? `$${formatMoney(spendableCents)}`
+        }
+        spendableSubtitle={spendableSubtitle}
+        spendableTone={spendableGradient}
+        spendableTooltip={spendableTooltip}
+        onOpenAlert={openThresholdModal}
+        availableValue={`$${formatMoney(availableCents)}`}
+        availableSubtitle={availableProjectedSubtitle}
+        availableTooltip={availableTooltip}
+        forecastValue={forecastDisplayValue ?? `$${formatMoney(forecastCents)}`}
+        forecastSubtitle={forecastSubtitle}
+        forecastTone={forecastGradient}
+        forecastTooltip={forecastTooltip}
+      />
       {dueSoonAlert}
 
       <Modal


### PR DESCRIPTION
Closes #15.

## What

Replaces the row of three equal `StatCard`s at the top of the Dashboard with a **hybrid, Spendable-first layout** (ticket #15's "revisit the balance-card visual language"):

- **Spendable** renders as a full-width hero (`2fr`) — 2.4rem number (was 1.7rem), state-coloured left edge, subtitle underneath.
- **Available** and **Forecast** demote to borderless mini-tiles in the remaining `1fr` column, each with a semantic dot.
- Collapses to a single column below 992px.

Spendable is the safety-net "source of truth" (`docs/PRODUCT.md`), so the hierarchy now says *read this number first* instead of giving all three equal weight. All three stay distinct tap targets with their own tooltips — that's why treatment B was picked over more radical options that dropped Available/Forecast as discrete objects.

State colour follows the existing `spendableGradient` / `forecastGradient` logic: healthy = a faint success left edge only (calm); negative or below the alert threshold = danger left edge + danger number + danger-tinted background (shouts).

## Files

| File | Change |
|---|---|
| `src/components/dashboard/BalanceCards.tsx` (new) | Presentation-only component; takes pre-formatted values from `Dashboard.tsx`. |
| `src/pages/Dashboard.tsx` | Swap the `<Row>` for `<BalanceCards>`; extract `availableTooltip` to a const; drop now-unused `Row`/`Col`/`StatCard` imports. |
| `src/index.css` | New `.balance-cards` / `.balance-hero` / `.balance-tile` block, on the existing semantic + `--duration-*` motion tokens. |

## Preserved

`aria-label="Spendable balance"`, click / Enter / Space to open the alert-threshold modal, `id="dashboard-spendable-card"` (`?scroll=spendable` deep-link target), `data-tour="balance-cards"`, the exact-match `Spendable` text node. Info-icon clicks no longer also open the hero's modal (`stopPropagation`).

## Follow-up (not in this PR)

`StatCard`'s non-compact branch and the `stat-card-flat*` CSS (~130 lines) now have zero callers — left for a separate dead-code sweep to keep this diff focused on the visual change.

## Checks

- `npm run validate` — clean
- `npx vitest run` — 595 pass
- `npx playwright test e2e/smoke.spec.ts` — 5 pass
- Manual (Playwright screenshot spec, sample data): renders correctly desktop + narrow; Spendable hero click opens the threshold modal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)