### PR TITLE
Chore: drop dead StatCard flat variant + stat-card-flat CSS

### DIFF
--- a/src/components/StatCard.tsx
+++ b/src/components/StatCard.tsx
@@ -3,123 +3,74 @@ import { Card, OverlayTrigger, Tooltip } from 'react-bootstrap'
 import { formatMoney } from '@/lib/format'
 
 type ColorVariant = 'primary' | 'danger' | 'info' | 'success'
-type SubtitleVariant = 'warning' | 'warningChip'
 
 export interface StatCardProps {
   title: string
   value: number
   subtitle?: ReactNode
-  subtitleVariant?: SubtitleVariant
   /** When set, shown instead of $formatMoney(value). Use for non-currency values (e.g. counts). */
   displayValue?: ReactNode
-  /** Smaller variant: less padding, smaller typography, gradient background. */
-  compact?: boolean
   gradient: ColorVariant
   /** Accepts plain strings or formatted JSX for richer multi-line tooltips. */
   tooltip?: ReactNode
 }
 
+/**
+ * Small pastel stat tile — title, a value, an optional subtitle, and an
+ * optional info-icon tooltip. Used for the Weekly Insights metric row.
+ */
 export function StatCard({
   title,
   value,
   subtitle,
-  subtitleVariant,
   displayValue,
-  compact,
   gradient,
   tooltip,
 }: StatCardProps) {
   const valueContent =
     displayValue != null ? displayValue : `$${formatMoney(value)}`
 
-  if (compact) {
-    const compactTitle = (
-      <>
-        {title}
-        {tooltip && (
-          <OverlayTrigger
-            placement="top"
-            trigger={['hover', 'focus', 'click']}
-            rootClose
-            overlay={
-              <Tooltip id={`stat-${title}-tooltip`} className="tooltip-rich">
-                {tooltip}
-              </Tooltip>
-            }
+  const titleContent = (
+    <>
+      {title}
+      {tooltip && (
+        <OverlayTrigger
+          placement="top"
+          trigger={['hover', 'focus', 'click']}
+          rootClose
+          overlay={
+            <Tooltip id={`stat-${title}-tooltip`} className="tooltip-rich">
+              {tooltip}
+            </Tooltip>
+          }
+        >
+          <span
+            className="ms-1"
+            style={{ cursor: 'help', fontSize: '0.75rem' }}
+            role="img"
+            aria-label="Info"
           >
-            <span
-              className="ms-1"
-              style={{ cursor: 'help', fontSize: '0.75rem' }}
-              role="img"
-              aria-label="Info"
-            >
-              <i className="mdi mdi-information-outline" aria-hidden />
-            </span>
-          </OverlayTrigger>
-        )}
-      </>
-    )
-    return (
-      <Card className={`bg-pastel-${gradient}`}>
-        <Card.Body className="py-1 px-2">
-          <h6 className="font-weight-normal mb-0 small text-center align-middle">
-            {compactTitle}
-          </h6>
-          <h6 className="mb-0 text-center align-middle fw-bold">
-            {valueContent}
-          </h6>
-          {subtitle && (
-            <small className="card-text d-block" style={{ opacity: 0.7 }}>
-              {subtitle}
-            </small>
-          )}
-        </Card.Body>
-      </Card>
-    )
-  }
+            <i className="mdi mdi-information-outline" aria-hidden />
+          </span>
+        </OverlayTrigger>
+      )}
+    </>
+  )
 
   return (
-    <Card className={`stat-card-flat stat-card-flat--${gradient}`}>
-      <Card.Body className="stat-card-flat__body">
+    <Card className={`bg-pastel-${gradient}`}>
+      <Card.Body className="py-1 px-2">
+        <h6 className="font-weight-normal mb-0 small text-center align-middle">
+          {titleContent}
+        </h6>
+        <h6 className="mb-0 text-center align-middle fw-bold">
+          {valueContent}
+        </h6>
         {subtitle && (
-          <div
-            className={`stat-card-flat__subtitle${subtitleVariant ? ` stat-card-flat__subtitle--${subtitleVariant}` : ''}`}
-          >
+          <small className="card-text d-block" style={{ opacity: 0.7 }}>
             {subtitle}
-          </div>
+          </small>
         )}
-
-        <div className="stat-card-flat__bottom-row">
-          <div className="stat-card-flat__header">
-            <div className="stat-card-flat__title">
-              {title}
-              {tooltip && (
-                <OverlayTrigger
-                  placement="top"
-                  trigger={['hover', 'focus', 'click']}
-                  rootClose
-                  overlay={
-                    <Tooltip
-                      id={`stat-${title}-tooltip`}
-                      className="tooltip-rich"
-                    >
-                      {tooltip}
-                    </Tooltip>
-                  }
-                >
-                  <span
-                    className="ms-1 stat-card-flat__info"
-                    role="img"
-                    aria-label="Info"
-                  >
-                    <i className="mdi mdi-information-outline" aria-hidden />
-                  </span>
-                </OverlayTrigger>
-              )}
-            </div>
-          </div>
-          <div className="stat-card-flat__value">{valueContent}</div>
-        </div>
       </Card.Body>
     </Card>
   )

--- a/src/components/dashboard/InsightsSection.tsx
+++ b/src/components/dashboard/InsightsSection.tsx
@@ -240,7 +240,6 @@ export function InsightsSection({
               title="Money In"
               value={insights.moneyIn}
               gradient="success"
-              compact
             />
           </Col>
           <Col xs={6} md>
@@ -248,7 +247,6 @@ export function InsightsSection({
               title="Money Out"
               value={insights.moneyOut}
               gradient="danger"
-              compact
             />
           </Col>
           <Col xs={6} md>
@@ -261,7 +259,6 @@ export function InsightsSection({
                 formatMoney(Math.abs(insights.saverChanges))
               }
               gradient="success"
-              compact
             />
           </Col>
           <Col xs={6} md>
@@ -271,7 +268,6 @@ export function InsightsSection({
               displayValue={insights.charges}
               gradient="danger"
               tooltip="Count of spending transactions this week (excludes transfers)."
-              compact
             />
           </Col>
         </Row>

--- a/src/index.css
+++ b/src/index.css
@@ -264,50 +264,33 @@
   box-shadow: 0 -4px 24px rgba(0, 0, 0, 0.15);
 }
 /* Pastel fill backgrounds: dark-tinted → white-tinted in light mode */
-[data-theme='light'] .bg-pastel-success,
-[data-theme='light'] .stat-card-flat--success {
+[data-theme='light'] .bg-pastel-success {
   background: linear-gradient(
     135deg,
     color-mix(in srgb, var(--vantura-success) 48%, white) 0%,
     color-mix(in srgb, var(--vantura-success) 38%, white) 100%
   );
 }
-[data-theme='light'] .bg-pastel-danger,
-[data-theme='light'] .stat-card-flat--danger {
+[data-theme='light'] .bg-pastel-danger {
   background: linear-gradient(
     135deg,
     color-mix(in srgb, var(--vantura-danger) 48%, white) 0%,
     color-mix(in srgb, var(--vantura-danger) 38%, white) 100%
   );
 }
-[data-theme='light'] .bg-pastel-info,
-[data-theme='light'] .stat-card-flat--info {
+[data-theme='light'] .bg-pastel-info {
   background: linear-gradient(
     135deg,
     color-mix(in srgb, var(--vantura-info) 48%, white) 0%,
     color-mix(in srgb, var(--vantura-info) 38%, white) 100%
   );
 }
-[data-theme='light'] .bg-pastel-primary,
-[data-theme='light'] .stat-card-flat--primary {
+[data-theme='light'] .bg-pastel-primary {
   background: linear-gradient(
     135deg,
     color-mix(in srgb, var(--vantura-primary) 48%, white) 0%,
     color-mix(in srgb, var(--vantura-primary) 38%, white) 100%
   );
-}
-/* Stat card border-left: dark-mix → white-mix in light mode */
-[data-theme='light'] .stat-card-flat--success {
-  border-left-color: color-mix(in srgb, var(--vantura-success) 60%, white);
-}
-[data-theme='light'] .stat-card-flat--danger {
-  border-left-color: color-mix(in srgb, var(--vantura-danger) 60%, white);
-}
-[data-theme='light'] .stat-card-flat--info {
-  border-left-color: color-mix(in srgb, var(--vantura-info) 60%, white);
-}
-[data-theme='light'] .stat-card-flat--primary {
-  border-left-color: color-mix(in srgb, var(--vantura-primary) 60%, white);
 }
 /* Auth screen gradient — light bg tinted by accent */
 [data-theme='light'] .auth-full-bg {
@@ -1219,151 +1202,6 @@ a:not(.btn):not(.nav-link):not(.dropdown-item):hover {
 }
 .balance-tile .balance-info {
   font-size: 0.8rem;
-}
-
-/* Flat stat card (Monarch-inspired) */
-.stat-card-flat {
-  border: 0;
-  border-left: 4px solid var(--vantura-primary);
-  border-radius: 6px;
-  background-color: var(--vantura-surface);
-  color: var(--vantura-text);
-  transition: box-shadow var(--duration-base) ease;
-}
-.stat-card-flat:hover {
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
-}
-.stat-card-flat--success {
-  background: linear-gradient(
-    135deg,
-    color-mix(in srgb, var(--vantura-success) 82%, white) 0%,
-    color-mix(in srgb, var(--vantura-success) 82%, #13131c) 100%
-  );
-  border-left-color: color-mix(in srgb, var(--vantura-success) 60%, #13131c);
-}
-.stat-card-flat--danger {
-  background: linear-gradient(
-    135deg,
-    color-mix(in srgb, var(--vantura-danger) 82%, white) 0%,
-    color-mix(in srgb, var(--vantura-danger) 82%, #13131c) 100%
-  );
-  border-left-color: color-mix(in srgb, var(--vantura-danger) 60%, #13131c);
-}
-.stat-card-flat--info {
-  background: linear-gradient(
-    135deg,
-    color-mix(in srgb, var(--vantura-info) 82%, white) 0%,
-    color-mix(in srgb, var(--vantura-info) 82%, #13131c) 100%
-  );
-  border-left-color: color-mix(in srgb, var(--vantura-info) 60%, #13131c);
-}
-.stat-card-flat--primary {
-  background: linear-gradient(
-    135deg,
-    color-mix(in srgb, var(--vantura-primary) 82%, white) 0%,
-    color-mix(in srgb, var(--vantura-primary) 82%, #13131c) 100%
-  );
-  border-left-color: color-mix(in srgb, var(--vantura-primary) 60%, #13131c);
-}
-/* Pastel gradient → soft dark text throughout */
-.stat-card-flat--success,
-.stat-card-flat--danger,
-.stat-card-flat--info,
-.stat-card-flat--primary {
-  color: rgba(26, 26, 46, 0.82);
-}
-.stat-card-flat--success .stat-card-flat__title,
-.stat-card-flat--danger .stat-card-flat__title,
-.stat-card-flat--info .stat-card-flat__title,
-.stat-card-flat--primary .stat-card-flat__title,
-.stat-card-flat--success .stat-card-flat__subtitle,
-.stat-card-flat--danger .stat-card-flat__subtitle,
-.stat-card-flat--info .stat-card-flat__subtitle,
-.stat-card-flat--primary .stat-card-flat__subtitle,
-.stat-card-flat--success .stat-card-flat__info,
-.stat-card-flat--danger .stat-card-flat__info,
-.stat-card-flat--info .stat-card-flat__info,
-.stat-card-flat--primary .stat-card-flat__info {
-  color: rgba(26, 26, 46, 0.58);
-}
-.stat-card-flat--success .stat-card-flat__value,
-.stat-card-flat--danger .stat-card-flat__value,
-.stat-card-flat--info .stat-card-flat__value,
-.stat-card-flat--primary .stat-card-flat__value {
-  color: rgba(26, 26, 46, 0.88);
-}
-/* Warning chip on a pastel card background — neutral dark tint instead of orange-on-pastel */
-.stat-card-flat--success .stat-card-flat__subtitle--warningChip,
-.stat-card-flat--danger .stat-card-flat__subtitle--warningChip,
-.stat-card-flat--info .stat-card-flat__subtitle--warningChip,
-.stat-card-flat--primary .stat-card-flat__subtitle--warningChip {
-  border-color: rgba(26, 26, 46, 0.25);
-  background: rgba(26, 26, 46, 0.12);
-  color: var(--vantura-text-on-pastel);
-}
-.stat-card-flat__body {
-  padding: 1.25rem 1.5rem !important;
-  display: flex;
-  flex-direction: column;
-  min-height: 100%;
-  justify-content: flex-start;
-  gap: 0.6rem;
-}
-.stat-card-flat__header {
-  display: flex;
-  align-items: flex-end;
-}
-.stat-card-flat__bottom-row {
-  display: flex;
-  align-items: flex-end;
-  justify-content: space-between;
-  gap: 0.75rem;
-  margin-top: auto;
-}
-.stat-card-flat__title {
-  font-size: 0.8rem;
-  font-weight: 500;
-  color: var(--vantura-text-secondary);
-  text-transform: uppercase;
-  letter-spacing: 0.04em;
-  display: inline-flex;
-  align-items: center;
-  white-space: nowrap;
-}
-.stat-card-flat__info {
-  cursor: help;
-  font-size: 0.85rem;
-  color: var(--vantura-text-secondary);
-}
-.stat-card-flat__value {
-  font-size: 1.7rem;
-  font-weight: 700;
-  color: var(--vantura-text);
-  line-height: 1.2;
-  text-align: right;
-  margin-top: 0;
-}
-.stat-card-flat__subtitle {
-  font-size: 0.8rem;
-  color: var(--vantura-text-secondary);
-  white-space: normal;
-  overflow-wrap: anywhere;
-  text-align: right;
-  align-self: flex-end;
-}
-.stat-card-flat__subtitle--warning {
-  color: var(--vantura-warning);
-  font-weight: 500;
-}
-.stat-card-flat__subtitle--warningChip {
-  display: inline-block;
-  margin-left: auto;
-  padding: 0.22rem 0.5rem;
-  border-radius: 0.375rem;
-  border: 1px solid color-mix(in srgb, var(--vantura-warning) 40%, transparent);
-  background: color-mix(in srgb, var(--vantura-warning) 18%, transparent);
-  color: var(--vantura-warning);
-  font-weight: 500;
 }
 
 /* Phase 8: Purple React sidebar */


### PR DESCRIPTION
## What

Follow-up to #71 (ticket #15). `BalanceCards` was the last caller of `StatCard`'s non-`compact` ("flat") branch, so that code + its CSS are now unreachable.

- **`StatCard.tsx`** — remove the `compact` prop and the `if (compact)` fork; the small pastel tile is now the only render path. Also drop `subtitleVariant` / `SubtitleVariant` (only the flat branch read it).
- **`InsightsSection.tsx`** — drop the now-redundant `compact` prop from its four `StatCard`s (the Weekly Insights metric row).
- **`index.css`** — delete the `.stat-card-flat*` block (~130 lines) and the `.stat-card-flat--*` halves of the light-theme pastel selector groups. `.bg-pastel-*` (used by the surviving tile) is kept.

## Not a visual change

The flat variant had zero callers after #71. The only rendered `StatCard` path — the Weekly Insights tiles — is byte-for-byte the same output.

## Checks

- `npm run validate` — clean
- `npx vitest run` — 595 pass
- `npx playwright test e2e/smoke.spec.ts` — 5 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)