### PR TITLE
Dashboard: Available balance shows −$X, not $-X, when negative

### DIFF
--- a/src/lib/format.test.ts
+++ b/src/lib/format.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest'
 import {
   formatMoney,
+  formatSignedMoney,
   formatDollars,
   formatDate,
   formatShortDate,
@@ -15,6 +16,23 @@ describe('formatMoney', () => {
     expect(formatMoney(100)).toBe('1.00')
     expect(formatMoney(12345)).toBe('123.45')
     expect(formatMoney(-500)).toBe('-5.00')
+  })
+})
+
+describe('formatSignedMoney', () => {
+  it('formats non-negative cents as a plain dollar amount', () => {
+    expect(formatSignedMoney(0)).toBe('$0.00')
+    expect(formatSignedMoney(100)).toBe('$1.00')
+    expect(formatSignedMoney(12345)).toBe('$123.45')
+  })
+  it('puts the minus sign outside the dollar symbol for negatives', () => {
+    expect(formatSignedMoney(-500)).toBe('−$5.00')
+    expect(formatSignedMoney(-12345)).toBe('−$123.45')
+  })
+  it('uses U+2212 MINUS SIGN, not an ASCII hyphen, and never "$-"', () => {
+    const out = formatSignedMoney(-500)
+    expect(out.startsWith('−')).toBe(true)
+    expect(out).not.toContain('$-')
   })
 })
 

--- a/src/lib/format.ts
+++ b/src/lib/format.ts
@@ -34,6 +34,18 @@ export function formatMoney(cents: number): string {
   })
 }
 
+/**
+ * Money for display with the sign *outside* the dollar symbol: `−$12.34`, not
+ * `$-12.34`. Use at any balance/amount call site that can go negative (Spendable,
+ * Forecast, Available). Non-negative values render as a plain `$12.34`; the minus
+ * is U+2212 (MINUS SIGN), matching the rest of the UI.
+ */
+export function formatSignedMoney(cents: number): string {
+  return cents < 0
+    ? `−$${formatMoney(Math.abs(cents))}`
+    : `$${formatMoney(cents)}`
+}
+
 /** Format dollars for display (e.g. tooltips, axis labels). Use when value is already in dollars. */
 export function formatDollars(dollars: number): string {
   return Number.isFinite(dollars)

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -12,7 +12,7 @@ import {
   type SpendableAlertMode,
 } from '@/services/balance'
 import { getForecastSpendable } from '@/services/forecast'
-import { formatMoney, formatShortDate } from '@/lib/format'
+import { formatMoney, formatSignedMoney, formatShortDate } from '@/lib/format'
 import { MONTH_NAMES } from '@/lib/constants'
 import { getAppSetting, setAppSetting } from '@/db'
 import { syncStore } from '@/stores/syncStore'
@@ -127,10 +127,7 @@ export function Dashboard() {
     spendableCents < effectiveThresholdCents
   const spendableGradient =
     spendableCents < 0 || isSpendableLow ? 'danger' : 'success'
-  const spendableDisplayValue =
-    spendableCents < 0
-      ? `−$${formatMoney(Math.abs(spendableCents))}`
-      : undefined
+  const spendableDisplayValue = formatSignedMoney(spendableCents)
   const isStale = lastSyncAgeMs != null && lastSyncAgeMs > 60 * 60 * 1000
   const staleHours =
     isStale && lastSyncAgeMs != null
@@ -147,8 +144,7 @@ export function Dashboard() {
       : 'Balance as reported by Up Bank'
 
   const forecastGradient = forecastCents < 0 ? 'danger' : 'info'
-  const forecastDisplayValue =
-    forecastCents < 0 ? `−$${formatMoney(Math.abs(forecastCents))}` : undefined
+  const forecastDisplayValue = formatSignedMoney(forecastCents)
   const forecastSubtitle =
     nextPayday && nextPayday.trim() !== ''
       ? `Projected for ${formatShortDate(nextPayday)}`
@@ -182,8 +178,6 @@ export function Dashboard() {
   )
 
   const spendableTooltip = (() => {
-    const fmtSigned = (c: number) =>
-      c < 0 ? `−$${formatMoney(Math.abs(c))}` : `$${formatMoney(c)}`
     const projected =
       payAmountCents != null ? spendableCents + payAmountCents : null
 
@@ -228,9 +222,9 @@ export function Dashboard() {
                 paddingTop: '0.3rem',
               }}
             >
-              After payday: {fmtSigned(spendableCents)} + $
+              After payday: {formatSignedMoney(spendableCents)} + $
               {formatMoney(payAmountCents!)} ={' '}
-              <strong>{fmtSigned(projected)}</strong>
+              <strong>{formatSignedMoney(projected)}</strong>
             </div>
           )}
         </div>
@@ -261,9 +255,9 @@ export function Dashboard() {
             paddingTop: '0.3rem',
           }}
         >
-          Post-payday: ${formatMoney(availableCents)} + $
+          Post-payday: {formatSignedMoney(availableCents)} + $
           {formatMoney(payAmountCents)} ={' '}
-          <strong>${formatMoney(availableCents + payAmountCents)}</strong>
+          <strong>{formatSignedMoney(availableCents + payAmountCents)}</strong>
         </div>
       )}
     </div>
@@ -647,17 +641,15 @@ export function Dashboard() {
         </div>
       </div>
       <BalanceCards
-        spendableValue={
-          spendableDisplayValue ?? `$${formatMoney(spendableCents)}`
-        }
+        spendableValue={spendableDisplayValue}
         spendableSubtitle={spendableSubtitle}
         spendableTone={spendableGradient}
         spendableTooltip={spendableTooltip}
         onOpenAlert={openThresholdModal}
-        availableValue={`$${formatMoney(availableCents)}`}
+        availableValue={formatSignedMoney(availableCents)}
         availableSubtitle={availableProjectedSubtitle}
         availableTooltip={availableTooltip}
-        forecastValue={forecastDisplayValue ?? `$${formatMoney(forecastCents)}`}
+        forecastValue={forecastDisplayValue}
         forecastSubtitle={forecastSubtitle}
         forecastTone={forecastGradient}
         forecastTooltip={forecastTooltip}


### PR DESCRIPTION
## What

The Available card rendered its value as `` `$${formatMoney(cents)}` ``, so an overdrawn transactional account showed **`$-123.45`** instead of **`−$123.45`** — the sign-placement bug from the ticket #15 audit, and inconsistent with Spendable / Forecast, which already do it right.

- **`src/lib/format.ts`** — new `formatSignedMoney(cents)`: minus sign *outside* the `$` (U+2212), plain `$X` for non-negatives.
- **`src/pages/Dashboard.tsx`** — Available card value + the "Post-payday" tooltip line now route through it. The identical inline logic in Spendable/Forecast (`spendableDisplayValue`, `forecastDisplayValue`, the tooltip's local `fmtSigned`) is folded into the same helper — output there is byte-identical, and the `?? \`$…\`` fallbacks at the `BalanceCards` call site drop out since the helper always returns a string.
- **`src/lib/format.test.ts`** — 3 cases for `formatSignedMoney` (non-negative, negative, and "never `$-`").

## Scope

Dashboard balance zone only. The ~20 other `formatMoney(Math.abs(...))` call sites elsewhere (transaction amounts, net-worth deltas, `+$` contexts) are left alone — different sign semantics, separate pass if wanted.

## Checks

- `npm run validate` — clean
- `npx vitest run` — 598 pass (595 + 3 new)
- `npx playwright test e2e/smoke.spec.ts` — 5 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)