### PR TITLE
Dashboard: Spendable hero announces its value to screen readers

### DIFF
--- a/src/components/dashboard/BalanceCards.tsx
+++ b/src/components/dashboard/BalanceCards.tsx
@@ -21,6 +21,12 @@ interface BalanceCardsProps {
   spendableSubtitle: ReactNode
   spendableTone: HeroTone
   spendableTooltip: ReactNode
+  /**
+   * Accessible name for the hero button. Built in Dashboard.tsx so it can fold
+   * in the formatted value, the reserved-until line, and any alert state — the
+   * visible value/subtitle nodes are not part of the button's name.
+   */
+  spendableAriaLabel: string
   onOpenAlert: () => void
   availableValue: ReactNode
   availableSubtitle: ReactNode
@@ -86,6 +92,7 @@ export function BalanceCards({
   spendableSubtitle,
   spendableTone,
   spendableTooltip,
+  spendableAriaLabel,
   onOpenAlert,
   availableValue,
   availableSubtitle,
@@ -109,7 +116,7 @@ export function BalanceCards({
             onOpenAlert()
           }
         }}
-        aria-label="Spendable balance; click to set low balance alert"
+        aria-label={spendableAriaLabel}
       >
         <div className="balance-hero__label">
           Spendable

--- a/src/components/dashboard/__tests__/BalanceCards.test.tsx
+++ b/src/components/dashboard/__tests__/BalanceCards.test.tsx
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest'
+import React from 'react'
+import ReactDOMServer from 'react-dom/server'
+import { BalanceCards } from '@/components/dashboard/BalanceCards'
+
+const baseProps = {
+  spendableValue: '$1,234.56',
+  spendableSubtitle: '$400.00 reserved until 5 Sep',
+  spendableTone: 'success' as const,
+  spendableTooltip: 'tip',
+  spendableAriaLabel:
+    'Spendable balance $1,234.56. $400.00 reserved until 5 Sep. Activate to set a low-balance alert.',
+  onOpenAlert: () => {},
+  availableValue: '$1,634.56',
+  availableSubtitle: 'Balance as reported by Up Bank',
+  availableTooltip: 'tip',
+  forecastValue: '$980.00',
+  forecastSubtitle: 'Projected to next payday',
+  forecastTone: 'info' as const,
+  forecastTooltip: 'tip',
+}
+
+describe('BalanceCards', () => {
+  it('uses the caller-supplied accessible name on the Spendable hero button', () => {
+    const html = ReactDOMServer.renderToString(<BalanceCards {...baseProps} />)
+
+    // The formatted value and reserved line reach the accessible name — the
+    // visible value/subtitle nodes on their own would not.
+    expect(html).toContain(`aria-label="${baseProps.spendableAriaLabel}"`)
+    expect(html).toContain('$1,234.56')
+    // The old hardcoded label is gone.
+    expect(html).not.toContain('click to set low balance alert')
+  })
+
+  it('keeps the deep-link id and tour hook on the hero', () => {
+    const html = ReactDOMServer.renderToString(<BalanceCards {...baseProps} />)
+
+    expect(html).toContain('id="dashboard-spendable-card"')
+    expect(html).toContain('data-tour="balance-cards"')
+    expect(html).toContain('role="button"')
+  })
+})

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -138,6 +138,16 @@ export function Dashboard() {
     nextPayday && nextPayday.trim() !== ''
       ? `$${formatMoney(reservedCents)} reserved until ${formatShortDate(nextPayday)}`
       : `$${formatMoney(reservedCents)} reserved for upcoming`
+  // The hero button's visible value/subtitle aren't part of its accessible
+  // name, so spell the whole picture out here — value, reserved line, and any
+  // alert state (mirrors the tooltip heading) — plus what activating it does.
+  const spendableStateNote =
+    spendableCents < 0
+      ? ' Spendable is negative.'
+      : isSpendableLow
+        ? ' Below your alert threshold.'
+        : ''
+  const spendableAriaLabel = `Spendable balance ${spendableDisplayValue}. ${spendableSubtitle}.${spendableStateNote} Activate to set a low-balance alert.`
   const availableProjectedSubtitle =
     payAmountCents != null
       ? `Projected post-payday: $${formatMoney(availableCents + payAmountCents)}`
@@ -645,6 +655,7 @@ export function Dashboard() {
         spendableSubtitle={spendableSubtitle}
         spendableTone={spendableGradient}
         spendableTooltip={spendableTooltip}
+        spendableAriaLabel={spendableAriaLabel}
         onOpenAlert={openThresholdModal}
         availableValue={formatSignedMoney(availableCents)}
         availableSubtitle={availableProjectedSubtitle}


### PR DESCRIPTION
## What

Last thread from the ticket #15 audit. The Spendable hero is a `role="button"` with a **static** `aria-label` (`"Spendable balance; click to set low balance alert"`), so its accessible name never included the dollar figure or the reserved-until line — those are visible-only child nodes and `aria-label` overrides contents.

- **`Dashboard.tsx`** — build the full accessible name from the strings already computed there: value + reserved line + any alert state (negative / below threshold, mirroring the tooltip heading) + what activating does. Pass it as `spendableAriaLabel`.
- **`BalanceCards.tsx`** — take the prop, drop the hardcoded string. Stays presentation-only.
- **`BalanceCards.test.tsx`** (new) — guards the wiring: supplied name lands on the hero and carries the value, old string gone, `?scroll=spendable` id + `data-tour` still present.

A screen reader now hears e.g. *"Spendable balance −$12.34. $400.00 reserved until 5 Sep. Below your alert threshold. Activate to set a low-balance alert., button"* instead of just the static phrase.

## Checks

- `npm run validate` — clean
- `npx vitest run` — 600 pass (598 + 2 new)
- `npx playwright test e2e/smoke.spec.ts` — 5 pass (`getByLabel(/Spendable balance/i)` still matches)

🤖 Generated with [Claude Code](https://claude.com/claude-code)