### PR TITLE
Money display: route signed/delta figures through shared formatters

### DIFF
--- a/src/components/charts/NetWorthTrendChart.tsx
+++ b/src/components/charts/NetWorthTrendChart.tsx
@@ -10,7 +10,7 @@ import {
   type NumberValue,
 } from 'd3'
 import type { NetWorthSnapshot } from '@/services/netWorth'
-import { formatMoney } from '@/lib/format'
+import { formatSignedMoney } from '@/lib/format'
 import { estimateLeftAxisValueLabelSpace } from '@/lib/chartLabelSpace'
 import { useChartDimensions } from '@/hooks/useChartDimensions'
 import { positionTooltip, setTooltipContent } from '@/lib/chartTooltip'
@@ -149,7 +149,7 @@ export function NetWorthTrendChart({
           year: 'numeric',
         })
         setTooltipContent(tooltipEl, dateLabel, [
-          `Net worth: ${point.total < 0 ? '−' : ''}$${formatMoney(Math.abs(point.total))}`,
+          `Net worth: ${formatSignedMoney(point.total)}`,
         ])
         tooltipEl.style.display = 'block'
         positionTooltip(tooltipEl, container, event, 160, 44)
@@ -174,10 +174,7 @@ export function NetWorthTrendChart({
 
     const yAxis = axisLeft(yScale)
       .ticks(4)
-      .tickFormat((d: NumberValue) => {
-        const val = Number(d)
-        return `${val < 0 ? '−' : ''}$${formatMoney(Math.abs(val))}`
-      })
+      .tickFormat((d: NumberValue) => formatSignedMoney(Number(d)))
       .tickSizeOuter(0)
 
     g.append('g').call(yAxis).style('font-size', '11px')

--- a/src/components/dashboard/NetWorthCard.tsx
+++ b/src/components/dashboard/NetWorthCard.tsx
@@ -3,7 +3,7 @@ import { useStore } from 'zustand'
 import { Link } from 'react-router-dom'
 import { Card } from 'react-bootstrap'
 import { syncStore } from '@/stores/syncStore'
-import { formatMoney } from '@/lib/format'
+import { formatMoney, formatSignedMoney, formatDeltaMoney } from '@/lib/format'
 import { getNetWorthSummary, getNetWorthSnapshots } from '@/services/netWorth'
 import { getManualAccounts, isStale } from '@/services/manualAccounts'
 import type React from 'react'
@@ -62,8 +62,7 @@ export function NetWorthCard({ dragHandleProps }: NetWorthCardProps) {
         <div className="d-flex align-items-baseline gap-2 mb-1">
           <span className="fw-semibold fs-4">
             {hasApproximate ? '≈ ' : ''}
-            {summary.totalCents < 0 ? '−' : ''}$
-            {formatMoney(Math.abs(summary.totalCents))}
+            {formatSignedMoney(summary.totalCents)}
           </span>
           {deltaVsPrev !== null && (
             <span
@@ -71,8 +70,7 @@ export function NetWorthCard({ dragHandleProps }: NetWorthCardProps) {
                 deltaVsPrev >= 0 ? 'text-success small' : 'text-danger small'
               }
             >
-              {deltaVsPrev >= 0 ? '↑' : '↓'} {deltaVsPrev >= 0 ? '+' : '−'}$
-              {formatMoney(Math.abs(deltaVsPrev))}
+              {deltaVsPrev >= 0 ? '↑' : '↓'} {formatDeltaMoney(deltaVsPrev)}
             </span>
           )}
         </div>

--- a/src/lib/format.test.ts
+++ b/src/lib/format.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest'
 import {
   formatMoney,
   formatSignedMoney,
+  formatDeltaMoney,
   formatDollars,
   formatDate,
   formatShortDate,
@@ -33,6 +34,21 @@ describe('formatSignedMoney', () => {
     const out = formatSignedMoney(-500)
     expect(out.startsWith('−')).toBe(true)
     expect(out).not.toContain('$-')
+  })
+})
+
+describe('formatDeltaMoney', () => {
+  it('shows an explicit + on positive deltas', () => {
+    expect(formatDeltaMoney(100)).toBe('+$1.00')
+    expect(formatDeltaMoney(12345)).toBe('+$123.45')
+  })
+  it('puts the minus sign outside the dollar symbol on negative deltas', () => {
+    expect(formatDeltaMoney(-100)).toBe('−$1.00')
+    expect(formatDeltaMoney(-12345)).toBe('−$123.45')
+    expect(formatDeltaMoney(-100)).not.toContain('$-')
+  })
+  it('shows no sign for a zero delta', () => {
+    expect(formatDeltaMoney(0)).toBe('$0.00')
   })
 })
 

--- a/src/lib/format.ts
+++ b/src/lib/format.ts
@@ -46,6 +46,18 @@ export function formatSignedMoney(cents: number): string {
     : `$${formatMoney(cents)}`
 }
 
+/**
+ * Like {@link formatSignedMoney} but also shows an explicit `+` on positives —
+ * `+$12.34` / `−$12.34` / `$0.00`. Use for *changes / deltas* where the
+ * direction is the point (net-worth movement, net flow, a period-over-period
+ * "Net" figure). A zero delta gets no sign.
+ */
+export function formatDeltaMoney(cents: number): string {
+  if (cents > 0) return `+$${formatMoney(cents)}`
+  if (cents < 0) return `−$${formatMoney(Math.abs(cents))}`
+  return `$${formatMoney(0)}`
+}
+
 /** Format dollars for display (e.g. tooltips, axis labels). Use when value is already in dollars. */
 export function formatDollars(dollars: number): string {
   return Number.isFinite(dollars)

--- a/src/pages/analytics/AnalyticsBudgetPlan.tsx
+++ b/src/pages/analytics/AnalyticsBudgetPlan.tsx
@@ -23,7 +23,7 @@ import {
   type BudgetBucketRow,
   type BucketCardSummary,
 } from '@/services/budgetBuckets'
-import { formatMoney } from '@/lib/format'
+import { formatMoney, formatSignedMoney } from '@/lib/format'
 import { syncStore } from '@/stores/syncStore'
 import { toast } from '@/stores/toastStore'
 import { BUCKET_ICONS, BUDGET_DISPLAY_PERIODS } from '@/lib/budgetBucketMeta'
@@ -739,8 +739,7 @@ export function AnalyticsBudgetPlan() {
                         : 'var(--vantura-danger)',
                   }}
                 >
-                  {freeSpendingCents < 0 ? '-' : ''}$
-                  {formatMoney(Math.abs(freeSpendingCents))}
+                  {formatSignedMoney(freeSpendingCents)}
                 </div>
               ) : (
                 <div className="text-muted small">Set income to calculate</div>

--- a/src/pages/analytics/AnalyticsNetWorth.tsx
+++ b/src/pages/analytics/AnalyticsNetWorth.tsx
@@ -3,7 +3,7 @@ import { useSearchParams } from 'react-router-dom'
 import { useStore } from 'zustand'
 import { Card, Row, Col, Modal, Button, Form, Badge } from 'react-bootstrap'
 import { syncStore } from '@/stores/syncStore'
-import { formatMoney } from '@/lib/format'
+import { formatMoney, formatSignedMoney } from '@/lib/format'
 import { getAccountsByTypes } from '@/services/accounts'
 import {
   getNetWorthSummary,
@@ -808,8 +808,7 @@ export function AnalyticsNetWorth() {
               <div className="small text-muted mb-1">Net Worth</div>
               <div className="fw-semibold fs-4">
                 {hasApproximate ? '≈ ' : ''}
-                {summary.totalCents < 0 ? '−' : ''}$
-                {formatMoney(Math.abs(summary.totalCents))}
+                {formatSignedMoney(summary.totalCents)}
               </div>
               {deltaVsPrev !== null && (
                 <div className="small mt-1">

--- a/src/pages/analytics/AnalyticsReports.tsx
+++ b/src/pages/analytics/AnalyticsReports.tsx
@@ -45,7 +45,12 @@ import { ComparisonDeltaBadge } from '@/components/atAGlance/ComparisonDeltaBadg
 import { buildDeltaTooltip } from '@/components/atAGlance/deltaTooltip'
 import { ComparisonVisual } from '@/components/atAGlance/ComparisonVisual'
 import { PageBreadcrumb } from '@/components/PageBreadcrumb'
-import { formatMoney, formatDollars, formatDate } from '@/lib/format'
+import {
+  formatMoney,
+  formatDeltaMoney,
+  formatDollars,
+  formatDate,
+} from '@/lib/format'
 import {
   monthNameLong,
   previousCalendarMonth,
@@ -852,7 +857,7 @@ export function AnalyticsReports() {
                 />
                 <KpiCell
                   label="Net"
-                  value={`${net >= 0 ? '+' : '−'}$${formatMoney(Math.abs(net))}`}
+                  value={formatDeltaMoney(net)}
                   valueClass={net >= 0 ? 'text-success' : 'text-danger'}
                   delta={
                     comparison?.hasPreviousData && netDelta

--- a/src/pages/analytics/AnalyticsSavers.tsx
+++ b/src/pages/analytics/AnalyticsSavers.tsx
@@ -25,7 +25,7 @@ import {
 } from '@/services/accounts'
 import { getMonthlyInsights } from '@/services/insights'
 import type { MonthDelta } from '@/services/insights'
-import { formatMoney } from '@/lib/format'
+import { formatMoney, formatSignedMoney, formatDeltaMoney } from '@/lib/format'
 import { syncStore } from '@/stores/syncStore'
 import { SaverBalanceChart } from '@/components/charts/SaverBalanceChart'
 import { SaverMonthlyFlowChart } from '@/components/charts/SaverMonthlyFlowChart'
@@ -948,8 +948,7 @@ export function AnalyticsSavers() {
                                   <span
                                     className={`fw-semibold ${netChange >= 0 ? 'text-success' : 'text-danger'}`}
                                   >
-                                    {netChange >= 0 ? '+' : '−'}$
-                                    {formatMoney(Math.abs(netChange))}
+                                    {formatDeltaMoney(netChange)}
                                   </span>
                                 </div>
                                 <div>
@@ -1021,7 +1020,7 @@ export function AnalyticsSavers() {
               visibility.
             </p>
             <p className="mb-3 fw-semibold">
-              Combined balance: ${formatMoney(homeLoanTotal)}
+              Combined balance: {formatSignedMoney(homeLoanTotal)}
             </p>
             <Row className="g-3">
               {homeLoans.map((a) => (
@@ -1029,7 +1028,7 @@ export function AnalyticsSavers() {
                   <Card className="h-100">
                     <Card.Body>
                       <h6 className="mb-1">{a.display_name}</h6>
-                      <p className="mb-0 h5">${formatMoney(a.balance)}</p>
+                      <p className="mb-0 h5">{formatSignedMoney(a.balance)}</p>
                     </Card.Body>
                   </Card>
                 </Col>


### PR DESCRIPTION
## What

Follow-up to #73 — the codebase-wide `formatSignedMoney` pass. `formatSignedMoney` existed but ~10 call sites still inlined the `x < 0 ? '−' : ''` + `$` + `formatMoney(Math.abs(x))` pattern, and one (Budget Plan **Free spending**) used an ASCII hyphen instead of the U+2212 minus used everywhere else.

- **`format.ts`** — add `formatDeltaMoney`: `+$X` / `−$X` / `$0.00`, for changes/deltas where the direction is the point.
- **Signed values → `formatSignedMoney`:** `NetWorthTrendChart` (tooltip + y-axis), `NetWorthCard` + `AnalyticsNetWorth` net-worth headline, `AnalyticsBudgetPlan` Free spending, `AnalyticsSavers` home-loan balances (Up `HOME_LOAN` syncs a negative balance).
- **Deltas → `formatDeltaMoney`:** `NetWorthCard` Δ-vs-snapshot, `AnalyticsSavers` net change, `AnalyticsReports` Net KPI.

## Behaviour

Identical, except:
- Free spending's minus is now `−`, not `-`.
- An exact-zero delta drops its `+` → `$0.00` (was `+$0.00`) at the 3 delta sites.

## Deliberately left (not sign-placement bugs)

- **Weekly Insights → Savers** metric — the sign is *inverted* (`saverChanges <= 0 ? '+'`), unsafe to fold mechanically.
- **Transaction rows** — `isDebit`-flag-driven, not the number's sign.
- **`AnalyticsNetWorth` Liabilities section** — deliberate `Math.abs` under a red "Liabilities" heading.
- Chart axis formatters over non-negative domains (budgets, spending, saver balances), and the ~180 other `formatMoney` sites showing structurally non-negative values (budgets, income, reserved, goals, limits, counts).

## Checks

- `npm run validate` — clean
- `npx vitest run` — 603 pass (600 + 3 new)
- `npx playwright test e2e/smoke.spec.ts` — 5 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)