### PR TITLE
Release v0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.10.0] - 2026-09-08
+
+The Dashboard's balance zone is rebuilt around Spendable as the headline figure, motion across the app moves onto one shared timing system with reduced-motion honoured throughout, and negative dollar amounts now render consistently as `−$X`.
+
 ### Changed
 
 - **The Dashboard leads with Spendable.** The three equal balance cards — Available, Spendable, Forecast — are replaced by a full-width Spendable hero: a large number with a colour that stays calm when the balance is healthy and turns red when it's negative or below your alert threshold, with Available and Forecast beside it as two smaller tiles. All three keep their own explanation tooltips, tapping Spendable still opens the low-balance alert settings, and the zone collapses to a single column on narrow screens.
+- **Motion is smoother and more consistent, and reduced-motion is respected everywhere.** The notification drawer now slides and fades both in and out (with its backdrop), transitions across the app share one timing scale, and when your device is set to reduce motion, animations are cut to a near-instant fade.
 
 ### Fixed
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -264,6 +264,20 @@ First release since the July audit (`v0.8.1`). Bundles the September feature-pol
 
 ---
 
+### v0.10.0 — Spendable-First Dashboard & Motion System — September 2026
+
+Builds on `v0.9.0` with a Dashboard balance-zone redesign, a shared motion / easing
+system adopted as the presentation-tier standard, and consistent negative-amount formatting.
+
+| Date | Feature |
+|------|---------|
+| Sep 8 | **`v0.10.0` released** — see [CHANGELOG](CHANGELOG.md#0100---2026-09-08) for the full list |
+| — | **Spendable-first balance zone** — the three equal Dashboard cards become a full-width Spendable hero with Available / Forecast as supporting mini-tiles; state colour on the hero's left edge ([#15](https://github.com/ostafford/Vantura_v3/issues/15)) |
+| — | **Motion token system** — shared `--ease-*` / `--duration-*` scale, app-wide `prefers-reduced-motion` baseline, ~40 ad-hoc transitions migrated; notification drawer gains real enter/exit + backdrop fade. Design-engineering adopted as the presentation-tier standard (ADR-0017) |
+| — | **Consistent `−$X`** — negative amounts render with the minus outside the `$` everywhere (Available, Net Worth, Budget Plan, Savers), via shared `formatSignedMoney` / `formatDeltaMoney` (#73, #75); Spendable card gains a screen-reader-complete accessible name (#74) |
+
+---
+
 ## Under Consideration
 
 Features that have been discussed or noted as potential future additions. Nothing here is committed.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vantura",
   "private": true,
-  "version": "0.9.0",
+  "version": "0.10.0",
   "type": "module",
   "scripts": {
     "prepare": "husky",

--- a/src/data/changelog.ts
+++ b/src/data/changelog.ts
@@ -24,6 +24,32 @@ export interface UpcomingItem {
 
 export const MILESTONES: Milestone[] = [
   {
+    date: '8 Sep 2026',
+    heading: 'Spendable-First Dashboard & Smoother Motion',
+    icon: 'mdi-view-dashboard-outline',
+    primaryMonth: '2026-09',
+    version: '0.10.0',
+    color: '#9fa8da',
+    items: [
+      {
+        icon: 'mdi-star-circle-outline',
+        text: "Your Dashboard now leads with Spendable — one full-width card with a large number and a colour that stays calm when your balance is healthy and turns red when it's low or negative. Available and Forecast sit alongside as smaller tiles.",
+      },
+      {
+        icon: 'mdi-motion-play-outline',
+        text: "Smoother, more consistent motion — the notification drawer slides and fades both in and out, animations across the app share one timing system, and if your device is set to reduce motion they're cut to a near-instant fade.",
+      },
+      {
+        icon: 'mdi-currency-usd',
+        text: 'Negative amounts now show consistently as −$X (minus before the dollar sign) everywhere — the Dashboard, Net Worth, Budget Plan and Savers.',
+      },
+      {
+        icon: 'mdi-account-eye-outline',
+        text: 'The Spendable card now reads its amount and status aloud to screen readers.',
+      },
+    ],
+  },
+  {
     date: '7 Sep 2026',
     heading: 'Automatic Colour, Recurring Charges & Saver Goals',
     icon: 'mdi-auto-fix',


### PR DESCRIPTION
21 commits since `v0.9.0`, in two batches.

**Design-engineering methodology + motion system**
- ADR-0017: design-engineering adopted as the presentation-tier standard
- Shared `--ease-*` / `--duration-*` token scale + app-wide `prefers-reduced-motion` baseline
- ~40 ad-hoc transitions migrated to the tokens
- Notification drawer: real enter/exit + backdrop fade, gentler reduced-motion variant

**Dashboard balance zone (#15)**
- Spendable-hero redesign — full-width hero + Available/Forecast mini-tiles (#71)
- Dead `StatCard` flat variant + `.stat-card-flat*` CSS removed (#72)
- Consistent `−$X` negative formatting via shared `formatSignedMoney` / `formatDeltaMoney` (#73, #75)
- Spendable card screen-reader accessible name (#74)

**Release bookkeeping**
- `package.json` 0.9.0 → 0.10.0 (feeds `__APP_VERSION__`)
- `CHANGELOG.md`: `[Unreleased]` → `[0.10.0] - 2026-09-08` + summary; fresh `[Unreleased]`
- `ROADMAP.md`: new v0.10.0 section
- `src/data/changelog.ts`: new `MILESTONES` entry driving What's New / `/changelog`

Tag `v0.10.0` to be cut on the merge commit after this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)